### PR TITLE
fix: support letter grade (text) results in ResultGraphic

### DIFF
--- a/src/smartschool/objects.py
+++ b/src/smartschool/objects.py
@@ -28,7 +28,7 @@ class CourseGraphic:
 
 
 @dataclass(config=_config)
-class ResultGraphic:
+class PercentageGraphic:
     type: Literal["percentage"]
     color: Literal["green", "red", "olive", "yellow", "steel"]
     value: int
@@ -45,6 +45,17 @@ class ResultGraphic:
     @property
     def percentage(self) -> float:
         return self.achieved_points / self.total_points
+
+
+@dataclass(config=_config)
+class TextGraphic:
+    type: Literal["text"]
+    color: Literal["green", "red", "olive", "yellow", "steel"]
+    value: String
+    description: String
+
+
+ResultGraphic = Annotated[PercentageGraphic | TextGraphic, Field(discriminator="type")]
 
 
 @dataclass(config=_config)

--- a/src/smartschool/results.pyi
+++ b/src/smartschool/results.pyi
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal
 
 from . import objects
-from .objects import Component, Course, Feedback, FeedbackFull, Period, ResultDetails, ResultGraphic, Teacher
+from .objects import Component, Course, Feedback, FeedbackFull, PercentageGraphic, Period, ResultDetails, Teacher, TextGraphic
 from .session import SessionMixin, Smartschool
 
 class Result(objects.Result, SessionMixin):
@@ -14,7 +14,7 @@ class Result(objects.Result, SessionMixin):
     identifier: str
     type: Literal["normal"]
     name: str
-    graphic: ResultGraphic
+    graphic: PercentageGraphic | TextGraphic
     date: datetime
     gradebook_owner: Teacher
     component: Component | None

--- a/tests/requests/get/results/api/v1/evaluations/letter_grades.json
+++ b/tests/requests/get/results/api/v1/evaluations/letter_grades.json
@@ -1,0 +1,279 @@
+[
+    {
+        "identifier": "1000_2000_0_normal_100001",
+        "type": "normal",
+        "name": "assignment linear algebra vectors",
+        "graphic": {
+            "type": "percentage",
+            "color": "olive",
+            "value": 100,
+            "description": "5/5"
+        },
+        "date": "2025-11-03T00:00:00+01:00",
+        "gradebookOwner": {
+            "id": "1000_1001_0",
+            "pictureHash": "initials_AJ",
+            "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_AJ/plain/1/res/128",
+            "description": {
+                "startingWithFirstName": "",
+                "startingWithLastName": ""
+            },
+            "name": {
+                "startingWithFirstName": "Anna Jansen",
+                "startingWithLastName": "Jansen Anna"
+            },
+            "sort": "jansen-anna",
+            "deleted": false
+        },
+        "component": {
+            "id": 2,
+            "name": "Daily work",
+            "abbreviation": "DW"
+        },
+        "courses": [
+            {
+                "id": 101,
+                "name": "Science Lab",
+                "graphic": {
+                    "type": "icon",
+                    "value": "science_beaker"
+                },
+                "teachers": [
+                    {
+                        "id": "1000_1002_0",
+                        "pictureHash": "initials_PD",
+                        "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_PD/plain/1/res/128",
+                        "description": {
+                            "startingWithFirstName": "",
+                            "startingWithLastName": ""
+                        },
+                        "name": {
+                            "startingWithFirstName": "Pieter De Vries",
+                            "startingWithLastName": "De Vries Pieter"
+                        },
+                        "sort": "de-vries-pieter",
+                        "deleted": false
+                    },
+                    {
+                        "id": "1000_1001_0",
+                        "pictureHash": "initials_AJ",
+                        "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_AJ/plain/1/res/128",
+                        "description": {
+                            "startingWithFirstName": "",
+                            "startingWithLastName": ""
+                        },
+                        "name": {
+                            "startingWithFirstName": "Anna Jansen",
+                            "startingWithLastName": "Jansen Anna"
+                        },
+                        "sort": "jansen-anna",
+                        "deleted": false
+                    }
+                ],
+                "class": {
+                    "identifier": "1000_2001",
+                    "id": 201,
+                    "platformId": 1000,
+                    "name": "Class 6A",
+                    "type": "K",
+                    "icon": "briefcase"
+                },
+                "skoreClassId": 301,
+                "parentCourseId": 1505,
+                "skoreWorkYear": {
+                    "id": 27,
+                    "dateRange": {
+                        "start": "2025-09-01T00:00:00+02:00",
+                        "end": "2026-08-31T00:00:00+02:00"
+                    }
+                }
+            }
+        ],
+        "period": {
+            "id": 1575,
+            "name": "Period 1",
+            "icon": "cal_purple_generic_week",
+            "class": {
+                "identifier": "1000_2001",
+                "id": 201,
+                "platformId": 1000,
+                "name": "Class 6A",
+                "type": "K",
+                "icon": "briefcase"
+            },
+            "skoreWorkYear": {
+                "id": 27,
+                "dateRange": {
+                    "start": "2025-09-01T00:00:00+02:00",
+                    "end": "2026-08-31T00:00:00+02:00"
+                }
+            },
+            "isActive": false
+        },
+        "feedback": [],
+        "feedbacks": [],
+        "availabilityDate": "2025-11-04T14:23:29+01:00",
+        "isPublished": true,
+        "doesCount": false
+    },
+    {
+        "identifier": "1000_2000_0_normal_100002",
+        "type": "normal",
+        "name": "Reading comprehension exercise",
+        "graphic": {
+            "type": "text",
+            "color": "yellow",
+            "value": "B",
+            "description": "First leaves"
+        },
+        "date": "2025-10-27T00:00:00+01:00",
+        "gradebookOwner": {
+            "id": "1000_1003_0",
+            "pictureHash": "initials_SB",
+            "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_SB/plain/1/res/128",
+            "description": {
+                "startingWithFirstName": "",
+                "startingWithLastName": ""
+            },
+            "name": {
+                "startingWithFirstName": "Sofie Bakker",
+                "startingWithLastName": "Bakker Sofie"
+            },
+            "sort": "bakker-sofie",
+            "deleted": false
+        },
+        "component": {
+            "id": 2,
+            "name": "Daily work",
+            "abbreviation": "DW"
+        },
+        "courses": [
+            {
+                "id": 102,
+                "name": "French",
+                "graphic": {
+                    "type": "icon",
+                    "value": "flag_generic"
+                },
+                "teachers": [
+                    {
+                        "id": "1000_1003_0",
+                        "pictureHash": "initials_SB",
+                        "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_SB/plain/1/res/128",
+                        "description": {
+                            "startingWithFirstName": "",
+                            "startingWithLastName": ""
+                        },
+                        "name": {
+                            "startingWithFirstName": "Sofie Bakker",
+                            "startingWithLastName": "Bakker Sofie"
+                        },
+                        "sort": "bakker-sofie",
+                        "deleted": false
+                    }
+                ],
+                "class": {
+                    "identifier": "1000_2001",
+                    "id": 201,
+                    "platformId": 1000,
+                    "name": "Class 6A",
+                    "type": "K",
+                    "icon": "briefcase"
+                },
+                "skoreClassId": 301,
+                "parentCourseId": 1209,
+                "skoreWorkYear": {
+                    "id": 27,
+                    "dateRange": {
+                        "start": "2025-09-01T00:00:00+02:00",
+                        "end": "2026-08-31T00:00:00+02:00"
+                    }
+                }
+            }
+        ],
+        "period": {
+            "id": 1575,
+            "name": "Period 1",
+            "icon": "cal_purple_generic_week",
+            "class": {
+                "identifier": "1000_2001",
+                "id": 201,
+                "platformId": 1000,
+                "name": "Class 6A",
+                "type": "K",
+                "icon": "briefcase"
+            },
+            "skoreWorkYear": {
+                "id": 27,
+                "dateRange": {
+                    "start": "2025-09-01T00:00:00+02:00",
+                    "end": "2026-08-31T00:00:00+02:00"
+                }
+            },
+            "isActive": false
+        },
+        "feedback": [
+            {
+                "user": {
+                    "id": "1000_1003_0",
+                    "pictureHash": "initials_SB",
+                    "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_SB/plain/1/res/128",
+                    "description": {
+                        "startingWithFirstName": "",
+                        "startingWithLastName": ""
+                    },
+                    "name": {
+                        "startingWithFirstName": "Sofie Bakker",
+                        "startingWithLastName": "Bakker Sofie"
+                    },
+                    "sort": "bakker-sofie",
+                    "deleted": false
+                },
+                "text": "Good understanding of the main ideas. Some minor errors in detail questions."
+            }
+        ],
+        "feedbacks": [
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "evaluationId": "1000_100002",
+                "student": {
+                    "id": "1000_2000_0",
+                    "pictureHash": "initials_JP",
+                    "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_JP/plain/1/res/128",
+                    "description": {
+                        "startingWithFirstName": "",
+                        "startingWithLastName": ""
+                    },
+                    "name": {
+                        "startingWithFirstName": "Jan Peeters",
+                        "startingWithLastName": "Peeters Jan"
+                    },
+                    "sort": "peeters-jan",
+                    "deleted": false
+                },
+                "teacher": {
+                    "id": "1000_1003_0",
+                    "pictureHash": "initials_SB",
+                    "pictureUrl": "https://userpicture.example.be/User/Userimage/hashimage/hash/initials_SB/plain/1/res/128",
+                    "description": {
+                        "startingWithFirstName": "",
+                        "startingWithLastName": ""
+                    },
+                    "name": {
+                        "startingWithFirstName": "Sofie Bakker",
+                        "startingWithLastName": "Bakker Sofie"
+                    },
+                    "sort": "bakker-sofie",
+                    "deleted": false
+                },
+                "text": "Good understanding of the main ideas. Some minor errors in detail questions.",
+                "createdAt": "2025-10-27T16:57:27+01:00",
+                "changedAt": "2025-10-27T17:19:50+01:00",
+                "attachments": []
+            }
+        ],
+        "availabilityDate": "2025-10-28T17:00:00+01:00",
+        "isPublished": true,
+        "doesCount": false
+    }
+]

--- a/tests/results_tests.py
+++ b/tests/results_tests.py
@@ -32,3 +32,22 @@ def test_mauro_results(session: Smartschool, requests_mock):
     result = sut[0]
     assert result.graphic.color == "olive"
     assert result.component is None
+
+
+def test_letter_grade_results(session: Smartschool, requests_mock):
+    letter_file = Path(__file__).parent / "requests/get/results/api/v1/evaluations/letter_grades.json"
+    requests_mock.get("https://site/results/api/v1/evaluations/?pageNumber=1&itemsOnPage=50", content=letter_file.read_bytes())
+    sut = list(Results(session))
+
+    assert len(sut) == 2
+
+    # Percentage result still works
+    assert sut[0].graphic.type == "percentage"
+    assert sut[0].graphic.value == 100
+
+    # Text/letter grade result
+    result = sut[1]
+    assert result.graphic.type == "text"
+    assert result.graphic.color == "yellow"
+    assert result.graphic.value == "B"
+    assert result.graphic.description == "First leaves"


### PR DESCRIPTION
## Summary
- **Fixes #108**: `ResultGraphic` only accepted `type='percentage'` with `int` value, but the API can also return `type='text'` with a string value (e.g. `'B'`) for letter grades
- Split `ResultGraphic` into `PercentageGraphic` and `TextGraphic` using a Pydantic discriminated union on the `type` field
- Added anonymized test data reproducing the issue and a test covering both percentage and text graphic types

## Test plan
- [x] New test `test_letter_grade_results` verifies text-type graphics parse correctly
- [x] Existing tests still pass (209/209)
- [x] Test data anonymized (no real names, IDs, or school URLs)