### PR TITLE
fix: use pull_request_target to support fork PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     # Only run on same-repo PRs (secrets are not available for fork PRs)
-    # if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:
@@ -44,4 +44,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -18,13 +18,10 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    # Only run on same-repo PRs (secrets are not available for fork PRs)
-    if: github.event.pull_request.head.repo.full_name == github.repository
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -32,6 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.base_ref }}
           fetch-depth: 1
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Summary

- Switch from `pull_request` to `pull_request_target` event
- Checkout base branch (`github.base_ref`) instead of fork head
- Grant `pull-requests: write` so Claude can post review comments

## Why

`pull_request` doesn't provide OIDC tokens for fork PRs, so Claude couldn't authenticate. `pull_request_target` runs in the base repo context, making secrets/OIDC available even for forks.

## Is this safe?

Yes — the security risk with `pull_request_target` is executing fork code. This workflow avoids that by:
- Checking out `github.base_ref` (master), never the fork's code
- The claude-code-action fetches the PR diff via GitHub API, so it still reviews all changes without running them locally

## Test plan
- [ ] Verify Claude posts a review on fork PRs (e.g. #117)
- [ ] Verify Claude still reviews same-repo PRs