### PR TITLE
fix(session): avoid re-firing every non-auth request

### DIFF
--- a/src/smartschool/session.py
+++ b/src/smartschool/session.py
@@ -81,11 +81,14 @@ class Smartschool(Session, DevTracingMixin):
 
     def _handle_auth_redirect(self, response: Response) -> Response:
         """
-        Handle authentication redirects with chain support.
+        Run the login/verification/2fa chain when the response is an auth page.
 
-        Precondition: ``response.url`` must already be an auth URL. Callers
-        must gate on ``self._is_auth_url(response.url)`` before invoking.
+        Returns the incoming response unchanged if it's not on an auth URL, so
+        callers can invoke this on any response without gating themselves.
         """
+        if not self._is_auth_url(response.url):
+            return response
+
         if self._login_attempts >= self._max_login_attempts:
             raise SmartSchoolAuthenticationError(f"Max login attempts ({self._max_login_attempts}) reached")
 
@@ -150,15 +153,18 @@ class Smartschool(Session, DevTracingMixin):
         # Make the request
         response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
-        # Only intervene if the response landed on an auth page — otherwise the
-        # request already succeeded and there is nothing to redo.
-        if self._is_auth_url(response.url):
-            response = self._handle_auth_redirect(response)
-            # If the caller wasn't explicitly asking for an auth URL, the auth
-            # flow was triggered mid-request: redo the original call now that
-            # we're authed to fetch its actual payload.
-            if not self._is_auth_url(full_url):
-                response = self._make_traced_request(super().request, method, full_url, **kwargs)
+        # Drive the auth chain if the response landed on a login page. The
+        # call is a no-op for non-auth responses, so no pre-check is needed
+        # here — but we still need to remember whether auth actually fired,
+        # so we can redo the caller's original request afterwards.
+        auth_redirected = self._is_auth_url(response.url)
+        response = self._handle_auth_redirect(response)
+
+        # If auth was triggered mid-request, redo the caller's original call
+        # now that we're logged in — unless the caller was explicitly driving
+        # the auth flow themselves (e.g. session.get("/login")).
+        if auth_redirected and not self._is_auth_url(full_url):
+            response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
         if not self._is_auth_url(response.url):
             self._reset_login_attempts()

--- a/src/smartschool/session.py
+++ b/src/smartschool/session.py
@@ -153,14 +153,23 @@ class Smartschool(Session, DevTracingMixin):
         # Make the request
         response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
-        # Redirected to a login page? Drive the auth chain once and redo the
-        # original request. No recursion — _handle_auth_redirect's
-        # login-attempts counter is what stops an auth loop.
-        if self._is_auth_url(response.url):
-            self._handle_auth_redirect(response)
+        # Drive the auth chain if the response landed on a login page. The
+        # call is a no-op for non-auth responses, so no pre-check is needed
+        # here — but we still need to remember whether auth actually fired,
+        # so we can redo the caller's original request afterwards.
+        auth_redirected = self._is_auth_url(response.url)
+        response = self._handle_auth_redirect(response)
+
+        # If auth was triggered mid-request, redo the caller's original call
+        # now that we're logged in — unless the caller was explicitly driving
+        # the auth flow themselves (e.g. session.get("/login")).
+        if auth_redirected and not self._is_auth_url(full_url):
             response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
-        self._reset_login_attempts()
+        if not self._is_auth_url(response.url):
+            self._reset_login_attempts()
+
+        # Save cookies
         self.cookies.save(ignore_discard=True)
 
         return response

--- a/src/smartschool/session.py
+++ b/src/smartschool/session.py
@@ -153,23 +153,14 @@ class Smartschool(Session, DevTracingMixin):
         # Make the request
         response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
-        # Drive the auth chain if the response landed on a login page. The
-        # call is a no-op for non-auth responses, so no pre-check is needed
-        # here — but we still need to remember whether auth actually fired,
-        # so we can redo the caller's original request afterwards.
-        auth_redirected = self._is_auth_url(response.url)
-        response = self._handle_auth_redirect(response)
-
-        # If auth was triggered mid-request, redo the caller's original call
-        # now that we're logged in — unless the caller was explicitly driving
-        # the auth flow themselves (e.g. session.get("/login")).
-        if auth_redirected and not self._is_auth_url(full_url):
+        # Redirected to a login page? Drive the auth chain once and redo the
+        # original request. No recursion — _handle_auth_redirect's
+        # login-attempts counter is what stops an auth loop.
+        if self._is_auth_url(response.url):
+            self._handle_auth_redirect(response)
             response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
-        if not self._is_auth_url(response.url):
-            self._reset_login_attempts()
-
-        # Save cookies
+        self._reset_login_attempts()
         self.cookies.save(ignore_discard=True)
 
         return response

--- a/src/smartschool/session.py
+++ b/src/smartschool/session.py
@@ -148,12 +148,17 @@ class Smartschool(Session, DevTracingMixin):
         # Make the request
         response = self._make_traced_request(super().request, method, full_url, **kwargs)
 
-        # Handle auth redirects
-        response = self._handle_auth_redirect(response)
-        if not self._is_auth_url(full_url):  # The original URL was NOT a login-url
-            response = self._make_traced_request(super().request, method, full_url, **kwargs)
-            self._reset_login_attempts()
-        elif not self._is_auth_url(response.url):  # Original was login, and this is not anymore
+        # Only intervene if the response landed on an auth page — otherwise the
+        # request already succeeded and there is nothing to redo.
+        if self._is_auth_url(response.url):
+            response = self._handle_auth_redirect(response)
+            # If the caller wasn't explicitly asking for an auth URL, the auth
+            # flow was triggered mid-request: redo the original call now that
+            # we're authed to fetch its actual payload.
+            if not self._is_auth_url(full_url):
+                response = self._make_traced_request(super().request, method, full_url, **kwargs)
+
+        if not self._is_auth_url(response.url):
             self._reset_login_attempts()
 
         # Save cookies

--- a/src/smartschool/session.py
+++ b/src/smartschool/session.py
@@ -79,11 +79,13 @@ class Smartschool(Session, DevTracingMixin):
             return self.cache_path / "authenticated_user.yml"
         return None
 
-    def _handle_auth_redirect(self, response: Response) -> Response | None:
-        """Handle authentication redirects with chain support."""
-        if not self._is_auth_url(response.url):
-            return None
+    def _handle_auth_redirect(self, response: Response) -> Response:
+        """
+        Handle authentication redirects with chain support.
 
+        Precondition: ``response.url`` must already be an auth URL. Callers
+        must gate on ``self._is_auth_url(response.url)`` before invoking.
+        """
         if self._login_attempts >= self._max_login_attempts:
             raise SmartSchoolAuthenticationError(f"Max login attempts ({self._max_login_attempts}) reached")
 

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -194,13 +194,14 @@ class TestAuthenticationFlow:
         assert session._is_auth_url("https://site/2fa/")
         assert not session._is_auth_url("https://site/dashboard")
 
-    def test_login_flow(self, session):
-        """Should handle complete login flow successfully."""
-        response = session.get("/login")
-        assert response.url.endswith("/dashboard")
+    def test_handle_auth_redirect_passes_through_non_auth_responses(self, session: Smartschool, mocker):
+        """_handle_auth_redirect must be safe to call on any response."""
+        response = mocker.Mock(spec=requests.Response, url="https://site/dashboard")
 
-        # Should eventually reach dashboard after auth
-        assert session._login_attempts == 0  # Reset after successful auth
+        result = session._handle_auth_redirect(response)
+
+        assert result is response
+        assert session._login_attempts == 0  # counter must not be polluted
 
     def test_authenticated_request_fires_single_http_call(self, session: Smartschool, requests_mock):
         """An already-authenticated request must hit the network exactly once."""

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -194,14 +194,13 @@ class TestAuthenticationFlow:
         assert session._is_auth_url("https://site/2fa/")
         assert not session._is_auth_url("https://site/dashboard")
 
-    def test_handle_auth_redirect_passes_through_non_auth_responses(self, session: Smartschool, mocker):
-        """_handle_auth_redirect must be safe to call on any response."""
-        response = mocker.Mock(spec=requests.Response, url="https://site/dashboard")
+    def test_login_flow(self, session):
+        """Should handle complete login flow successfully."""
+        response = session.get("/login")
+        assert response.url.endswith("/dashboard")
 
-        result = session._handle_auth_redirect(response)
-
-        assert result is response
-        assert session._login_attempts == 0  # counter must not be polluted
+        # Should eventually reach dashboard after auth
+        assert session._login_attempts == 0  # Reset after successful auth
 
     def test_authenticated_request_fires_single_http_call(self, session: Smartschool, requests_mock):
         """An already-authenticated request must hit the network exactly once."""

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -202,6 +202,34 @@ class TestAuthenticationFlow:
         # Should eventually reach dashboard after auth
         assert session._login_attempts == 0  # Reset after successful auth
 
+    def test_authenticated_request_fires_single_http_call(self, session: Smartschool, requests_mock):
+        """An already-authenticated request must hit the network exactly once."""
+        target = "https://site/api/v1/echo"
+        requests_mock.get(target, text="ok")
+
+        session.get("/api/v1/echo")
+
+        matching = [r for r in requests_mock.request_history if r.url == target]
+        assert len(matching) == 1
+
+    def test_expired_session_retries_original_request_after_auth(self, session: Smartschool, requests_mock):
+        """When the first attempt is redirected to login, the original request must be retried exactly once after auth completes."""
+        target = "https://site/api/v1/protected"
+        requests_mock.get(
+            target,
+            [
+                {"status_code": 302, "headers": {"Location": "https://site/login"}},
+                {"status_code": 200, "text": "authorized"},
+            ],
+        )
+
+        response = session.get("/api/v1/protected")
+
+        assert response.status_code == 200
+        assert response.text == "authorized"
+        protected_calls = [r for r in requests_mock.request_history if r.url == target]
+        assert len(protected_calls) == 2
+
     def test_max_login_attempts_exceeded(self, session):
         """Should raise error when max login attempts exceeded."""
         session._login_attempts = 3


### PR DESCRIPTION
## Summary

`Smartschool.request()` was firing every non-auth HTTP call **twice** against the network. The intent of the original logic was *"if the first attempt got redirected to login, handle the auth and then retry the original request"*, but the retry guard only looked at the caller's URL — not at whether an auth redirect actually happened. Result: every already-authenticated `GET`/`POST` round-tripped twice.

- For reads: wasted bandwidth and latency on every API call in the library.
- For mutating calls: duplicated side effects. The compose/send PR #117 had to bypass `self.session.post` in `add_attachment` precisely to avoid uploading each file twice, and other mutating endpoints (label change, archive, trash) were silently hitting the server twice as well.

## Fix

Only re-fire the request when the first response actually landed on an auth page *and* the caller wasn't explicitly asking for that auth URL. Direct `session.get('/login')` still drives the full auth chain as before.

## Test plan

- [x] New TDD test `test_authenticated_request_fires_single_http_call` — red-then-green, pins single-call behavior for the authed happy path.
- [x] New test `test_expired_session_retries_original_request_after_auth` — pins retry-once when the session has expired mid-request.
- [x] Existing `test_login_flow` still passes (direct `session.get('/login')` → dashboard).
- [x] Existing `test_successful_request_resets_login_attempts` still passes.
- [x] Full suite: 209 passed, 2 skipped locally.

## Follow-ups

- Once this lands, the `RequestsSession.request(self.session, …)` bypass in `message_composer.add_attachment` (PR #117) can be replaced with a plain `self.session.post(…)` and the NOTE comment removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)