### PR TITLE
chore: exclude test fixtures from SonarCloud analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,3 @@
+# Test fixture files are raw responses captured from the smartschool
+# server — not code we author or control. Exclude from analysis.
+sonar.exclusions=tests/requests/**


### PR DESCRIPTION
Adds `.sonarcloud.properties` to exclude `tests/requests/**` from automatic analysis.

These files are raw HTML/XML responses captured from the smartschool server, used as test fixtures. SonarCloud flags them for security hotspots, duplication, and reliability issues that aren't actionable — they're not authored code.

Note: automatic analysis reads `.sonarcloud.properties`, not `sonar-project.properties`. The latter was mistakenly added on PR #117's branch and has no effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)