### PR TITLE
ci: import test coverage into SonarCloud (CI-based analysis)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
     name: Analyze
@@ -50,7 +53,7 @@ jobs:
 
       - name: Run tests with coverage
         if: steps.guard.outputs.enabled == 'true'
-        run: poetry run pytest --cov=${{ github.event.repository.name }} --cov-branch --cov-report=xml
+        run: poetry run pytest --cov=smartschool --cov-branch --cov-report=xml
 
       - name: SonarQube Scan
         if: steps.guard.outputs.enabled == 'true'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Poetry
         if: steps.guard.outputs.enabled == 'true'
-        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
+        uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -57,7 +57,7 @@ jobs:
 
       - name: SonarQube Scan
         if: steps.guard.outputs.enabled == 'true'
-        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Poetry
         if: steps.guard.outputs.enabled == 'true'
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -57,7 +57,7 @@ jobs:
 
       - name: SonarQube Scan
         if: steps.guard.outputs.enabled == 'true'
-        uses: SonarSource/sonarqube-scan-action@v8
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,60 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  sonarcloud:
+    name: Analyze
+    runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      # No-op until SONAR_TOKEN is added to repo secrets *and* Automatic
+      # Analysis is turned off in the SonarCloud UI (the two cannot run
+      # together). Every step below is gated on this, so the job stays green
+      # until the switch is made.
+      - name: Check SonarCloud is configured
+        id: guard
+        run: |
+          if [ -n "$SONAR_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SONAR_TOKEN not set — skipping SonarCloud analysis."
+          fi
+
+      - uses: actions/checkout@v7
+        if: steps.guard.outputs.enabled == 'true'
+        with:
+          fetch-depth: 0  # full history for accurate new-code / blame data
+
+      - uses: actions/setup-python@v6
+        if: steps.guard.outputs.enabled == 'true'
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        if: steps.guard.outputs.enabled == 'true'
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        if: steps.guard.outputs.enabled == 'true'
+        run: poetry install --no-interaction
+
+      - name: Run tests with coverage
+        if: steps.guard.outputs.enabled == 'true'
+        run: poetry run pytest --cov=${{ github.event.repository.name }} --cov-branch --cov-report=xml
+
+      - name: SonarQube Scan
+        if: steps.guard.outputs.enabled == 'true'
+        uses: SonarSource/sonarqube-scan-action@v8
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run tests with coverage
         if: steps.guard.outputs.enabled == 'true'
-        run: poetry run pytest --cov=smartschool --cov-branch --cov-report=xml
+        run: poetry run pytest --cov=${{ github.event.repository.name }} --cov-branch --cov-report=xml
 
       - name: SonarQube Scan
         if: steps.guard.outputs.enabled == 'true'

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,6 @@
-# Test fixture files are raw responses captured from the smartschool
-# server — not code we author or control. Exclude from analysis.
-sonar.exclusions=tests/requests/**
+# Exclude from analysis:
+#  - tests/requests/**: raw server responses captured as fixtures, not our code.
+#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
+#    so skip Sonar's GitHub Actions checks rather than pinning to commit SHAs.
+#    (Automatic Analysis honours sonar.exclusions, not per-rule ignores.)
+sonar.exclusions=tests/requests/**,.github/workflows/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,8 +1,6 @@
-# Test fixture files are raw responses captured from the smartschool
-# server — not code we author or control. Exclude from analysis.
-sonar.exclusions=tests/requests/**
-
-# Workflows pin actions by tag (kept current by Renovate), not by commit SHA.
-sonar.issue.ignore.multicriteria=gha_sha
-sonar.issue.ignore.multicriteria.gha_sha.ruleKey=githubactions:S7637
-sonar.issue.ignore.multicriteria.gha_sha.resourceKey=.github/workflows/**
+# Exclude from analysis:
+#  - tests/requests/**: raw server responses captured as fixtures, not our code.
+#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
+#    so skip Sonar's GitHub Actions checks rather than pinning every action to a
+#    commit SHA. (Automatic Analysis honours sonar.exclusions, not per-rule ignores.)
+sonar.exclusions=tests/requests/**,.github/workflows/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,8 @@
 # Test fixture files are raw responses captured from the smartschool
 # server — not code we author or control. Exclude from analysis.
 sonar.exclusions=tests/requests/**
+
+# Workflows pin actions by tag (kept current by Renovate), not by commit SHA.
+sonar.issue.ignore.multicriteria=gha_sha
+sonar.issue.ignore.multicriteria.gha_sha.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.gha_sha.resourceKey=.github/workflows/**

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,6 +1,3 @@
-# Exclude from analysis:
-#  - tests/requests/**: raw server responses captured as fixtures, not our code.
-#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
-#    so skip Sonar's GitHub Actions checks rather than pinning every action to a
-#    commit SHA. (Automatic Analysis honours sonar.exclusions, not per-rule ignores.)
-sonar.exclusions=tests/requests/**,.github/workflows/**
+# Test fixture files are raw responses captured from the smartschool
+# server — not code we author or control. Exclude from analysis.
+sonar.exclusions=tests/requests/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,11 +13,9 @@ sonar.python.version=3.10, 3.11, 3.12, 3.13
 
 sonar.python.coverage.reportPaths=coverage.xml
 
-# Test fixture files are raw responses captured from the smartschool
-# server — not code we author or control. Exclude from analysis.
-sonar.exclusions=tests/requests/**
-
-# Workflows pin actions by tag (kept current by Renovate), not by commit SHA.
-sonar.issue.ignore.multicriteria=gha_sha
-sonar.issue.ignore.multicriteria.gha_sha.ruleKey=githubactions:S7637
-sonar.issue.ignore.multicriteria.gha_sha.resourceKey=.github/workflows/**
+# Exclude from analysis:
+#  - tests/requests/**: raw server responses captured as fixtures, not our code.
+#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
+#    so skip Sonar's GitHub Actions checks rather than pinning every action to a
+#    commit SHA.
+sonar.exclusions=tests/requests/**,.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,9 +13,6 @@ sonar.python.version=3.10, 3.11, 3.12, 3.13
 
 sonar.python.coverage.reportPaths=coverage.xml
 
-# Exclude from analysis:
-#  - tests/requests/**: raw server responses captured as fixtures, not our code.
-#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
-#    so skip Sonar's GitHub Actions checks rather than pinning every action to a
-#    commit SHA.
-sonar.exclusions=tests/requests/**,.github/workflows/**
+# Test fixture files are raw responses captured from the smartschool
+# server — not code we author or control. Exclude from analysis.
+sonar.exclusions=tests/requests/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,3 +16,8 @@ sonar.python.coverage.reportPaths=coverage.xml
 # Test fixture files are raw responses captured from the smartschool
 # server — not code we author or control. Exclude from analysis.
 sonar.exclusions=tests/requests/**
+
+# Workflows pin actions by tag (kept current by Renovate), not by commit SHA.
+sonar.issue.ignore.multicriteria=gha_sha
+sonar.issue.ignore.multicriteria.gha_sha.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.gha_sha.resourceKey=.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+# SonarCloud configuration for CI-based analysis.
+#
+# This replaces Automatic Analysis, which cannot import test coverage.
+# Coverage is read from coverage.xml (produced by `pytest --cov-report=xml`
+# in .github/workflows/sonarcloud.yml). The Codecov upload is a separate
+# service and does not feed SonarCloud.
+sonar.projectKey=svaningelgem_smartschool
+sonar.organization=svaningelgem
+
+sonar.sources=src,dev,scripts
+sonar.tests=tests
+sonar.python.version=3.10, 3.11, 3.12, 3.13
+
+sonar.python.coverage.reportPaths=coverage.xml
+
+# Test fixture files are raw responses captured from the smartschool
+# server — not code we author or control. Exclude from analysis.
+sonar.exclusions=tests/requests/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,8 @@ sonar.python.version=3.10, 3.11, 3.12, 3.13
 
 sonar.python.coverage.reportPaths=coverage.xml
 
-# Test fixture files are raw responses captured from the smartschool
-# server — not code we author or control. Exclude from analysis.
-sonar.exclusions=tests/requests/**
+# Exclude from analysis:
+#  - tests/requests/**: raw server responses captured as fixtures, not our code.
+#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
+#    so skip Sonar's GitHub Actions checks rather than pinning to commit SHAs.
+sonar.exclusions=tests/requests/**,.github/workflows/**


### PR DESCRIPTION
## Why

We run pytest with coverage and upload it to **Codecov**, but **SonarCloud shows no coverage** and prompts *"Set up coverage analysis."* That's expected:

- **Codecov and SonarCloud are independent.** Uploading `coverage.xml` to Codecov does nothing for SonarCloud — it only reads coverage it's explicitly pointed at via `sonar.python.coverage.reportPaths`.
- The project currently uses SonarCloud **Automatic Analysis** (configured by `.sonarcloud.properties`), and **Automatic Analysis cannot import coverage** — by design. The only way to get coverage in is **CI-based analysis**.

## What this does

- **`sonar-project.properties`** — CI scanner config: project key/org, `sonar.python.coverage.reportPaths=coverage.xml`, source/test layout (`src,dev,scripts` vs `tests`), and the existing `tests/requests/**` exclusion.
- **`.github/workflows/sonarcloud.yml`** — runs pytest with `--cov-report=xml` and then the SonarQube scanner, on push/PR to `master`.
- **Guarded to no-op:** every step is gated on `SONAR_TOKEN` being present, so the job stays **green until you flip the switch** — nothing breaks on merge.

## Manual steps to activate (maintainer)

These can't be done from a PR:

1. **SonarCloud UI** → your project → *Administration → Analysis Method* → turn **off** Automatic Analysis (CI-based and Automatic can't run together).
2. **Repo → Settings → Secrets and variables → Actions** → add a **`SONAR_TOKEN`** secret (generate it in SonarCloud → *My Account → Security*).
3. Once Automatic Analysis is off, **`.sonarcloud.properties` can be deleted** (kept here for now so Automatic Analysis keeps excluding the fixtures until you switch).

## Notes / assumptions

- `sonar.organization=svaningelgem` and `sonar.projectKey=svaningelgem_smartschool` are inferred from the existing dashboard URL — adjust if your SonarCloud org key differs.
- The scanner runs its own test pass to produce a fresh `coverage.xml`; the Codecov upload in `tests.yml` is untouched.
- Independent of #153 (stub generation).