### PR TITLE
ci: exclude captured fixtures from Sonar via sonar.test.exclusions

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,6 +1,0 @@
-# Exclude from analysis:
-#  - tests/requests/**: raw server responses captured as fixtures, not our code.
-#  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
-#    so skip Sonar's GitHub Actions checks rather than pinning to commit SHAs.
-#    (Automatic Analysis honours sonar.exclusions, not per-rule ignores.)
-sonar.exclusions=tests/requests/**,.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,11 +13,17 @@ sonar.python.version=3.10, 3.11, 3.12, 3.13
 
 sonar.python.coverage.reportPaths=coverage.xml
 
-# Exclude from analysis:
-#  - tests/requests/**: raw server responses captured as fixtures, not our code.
+# Exclude main sources from analysis:
 #  - .github/workflows/**: actions are pinned by tag (kept current by Renovate),
 #    so skip Sonar's GitHub Actions checks rather than pinning to commit SHAs.
-sonar.exclusions=tests/requests/**,.github/workflows/**
+sonar.exclusions=.github/workflows/**
+
+# Exclude test files from analysis. sonar.exclusions only filters main sources
+# (sonar.sources); files under sonar.tests need sonar.test.exclusions instead.
+#  - tests/requests/**: raw server responses captured as fixtures, not our code.
+#    Left in, the captured HTML/JS raises bugs/vulnerabilities that fail the
+#    new-code Reliability/Security gate.
+sonar.test.exclusions=tests/requests/**
 
 # Exclude from the coverage gate (still analysed for bugs/smells/complexity):
 #  - dev/** and scripts/**: developer tooling, not the shipped library. Coverage


### PR DESCRIPTION
## Why the SonarCloud badge is red

The quality-gate badge reflects the **master** branch gate, which fails on:

- **C Reliability Rating on New Code** (needs ≥ A)
- **C Security Rating on New Code** (needs ≥ A)

The only open issues driving those ratings are 5, all inside one captured fixture — `tests/requests/get/composemessage/new-message.html` (raw Smartschool HTML/JS, not our code):

- 4× `javascript:S1534` — duplicate attribute names (bugs → Reliability)
- 1× `javascript:S2245` — weak PRNG (vulnerability → Security)

## Root cause

`sonar.exclusions=tests/requests/**` was supposed to exclude these — but `tests/` is declared as `sonar.tests`, so the fixtures are **test files**, and `sonar.exclusions` only filters **main sources** (`sonar.sources`). Test files need **`sonar.test.exclusions`**. The pattern matched nothing, so the captured pages were analysed and their JS issues failed the gate.

## Changes

- Move `tests/requests/**` to `sonar.test.exclusions`; keep `.github/workflows/**` under `sonar.exclusions`.
- **Delete `.sonarcloud.properties`.** It configures only SonarCloud *Automatic Analysis*, which #155 replaced with *CI-based analysis* (`sonar-project.properties`, read by the scan action). The two modes are mutually exclusive — with CI analysis running, that file is never read. It was dead config duplicating the exclusions.

After the next master analysis, new-code bugs/vulnerabilities drop to 0 → ratings return to A → gate passes → badge green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)