### PR TITLE
ci: fix release workflow assets, changelog push, and notes formatting

### DIFF
--- a/.github/changelog/changelog.md.j2
+++ b/.github/changelog/changelog.md.j2
@@ -3,7 +3,7 @@
 
 {% for change_key, changes in entry.changes.items() %}
 {% for change in changes %}
-- {{ change_key | lower }}{% if change.scope %}({{ change.scope }}){% endif %}: {{ change.message }}
+- {{ change_key | lower }}{% if change.scope %}({{ change.scope }}){% endif %}: {{ change.message | replace("\n", " ") }}
 {% endfor %}
 {% endfor %}
 

--- a/.github/changelog/release_notes.md.j2
+++ b/.github/changelog/release_notes.md.j2
@@ -1,7 +1,6 @@
 {% set icons = {"Feat": "✨", "Fix": "🔧", "Refactor": "♻️", "Perf": "⚡", "BREAKING CHANGE": "💥"} %}
 {% for entry in tree %}
-## {{ entry.version }}{{ " (" ~ entry.date ~ ")" if entry.date else "" }}
-
+{# Version + date header omitted: GitHub already shows them as the release title. #}
 {% for change_key, changes in entry.changes.items() %}
 ### {{ icons.get(change_key, "📌") }} {{ change_key }}
 

--- a/.github/changelog/release_notes.md.j2
+++ b/.github/changelog/release_notes.md.j2
@@ -5,7 +5,7 @@
 ### {{ icons.get(change_key, "📌") }} {{ change_key }}
 
 {% for change in changes %}
-- {% if change.scope %}**{{ change.scope }}**: {% endif %}{{ change.message }}
+- {% if change.scope %}**{{ change.scope }}**: {% endif %}{{ change.message | replace("\n", " ") }}
 {% endfor %}
 
 {% endfor %}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           poetry run cz changelog "$VERSION" --dry-run --template .github/changelog/release_notes.md.j2 > release-notes.md
-          gh release create "$VERSION" dist/* --title "$VERSION" --notes-file release-notes.md
+          # Only the installable distributions; the *.publish.attestation files the
+          # PyPI publish step drops into dist/ live on PyPI, not the GitHub release.
+          gh release create "$VERSION" dist/*.whl dist/*.tar.gz --title "$VERSION" --notes-file release-notes.md
 
       # Push the changelog to master only after a successful publish, so a failed
       # release never leaves a changelog entry for a version that isn't on PyPI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           ref: master       # tag is created on master HEAD; check out the branch so we can commit to it
           fetch-depth: 0    # full history + all tags so commitizen can build the changelog
+          # Push the changelog back to the protected master with an admin PAT.
+          # The default github-actions[bot] token can't bypass the required-PR
+          # rule; enforce_admins is off, so an admin token pushes directly.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1


### PR DESCRIPTION
Several related fixes to the release workflow and its changelog/notes templates.

1. **Attestation assets** — restrict `gh release create` to `dist/*.whl dist/*.tar.gz`. The PyPI publish step writes `*.publish.attestation` files into `dist/`, so the old `dist/*` glob swept them onto the GitHub release. They belong on PyPI (which verifies them), not the release page.

2. **Changelog write-back to master** — the post-release changelog commit failed because the default `github-actions[bot]` token can't bypass the required-pull-request rule. Check out master with a `RELEASE_PAT` secret instead; `enforce_admins` is off, so an admin token pushes directly. **Requires a `RELEASE_PAT` repository secret** (admin PAT with Contents: write).

3. **Redundant release header** — drop the `## x.y.z (date)` line from `release_notes.md.j2`; GitHub already renders the version and date as the release title, so it was duplicated at the top of every release page.

4. **Hard-wrapped footers** — collapse newlines within each change message in both templates (`release_notes.md.j2`, `changelog.md.j2`), so a `BREAKING CHANGE:` (or any footer) hard-wrapped in a commit renders on one line instead of splitting mid-sentence.
