### PR TITLE
ci: run tests/lint/sonar only when python-relevant files change

### DIFF
--- a/.github/workflows/codecov-gate.yml
+++ b/.github/workflows/codecov-gate.yml
@@ -47,7 +47,7 @@ jobs:
           set -euo pipefail
           files="$(gh api --paginate "/repos/${REPO}/pulls/${PR}/files" --jq '.[].filename')"
           # Mirror the paths that make tests.yml run pytest + upload coverage.
-          if echo "$files" | grep -qE '(\.py$|^poetry\.lock$|^pyproject\.toml$|^\.github/workflows/tests\.yml$)'; then
+          if echo "$files" | grep -qE '(\.py$|\.pyi$|^poetry\.lock$|^pyproject\.toml$|^\.github/workflows/tests\.yml$)'; then
             state=pending
             desc="waiting for codecov to report"
           else

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,8 +3,16 @@ name: SonarCloud
 on:
   push:
     branches: [ "master" ]
+    paths: &python-paths
+      - '**/*.py'
+      - '**/*.pyi'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - 'sonar-project.properties'
+      - '.github/workflows/sonarcloud.yml'
   pull_request:
     branches: [ "master" ]
+    paths: *python-paths
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,15 @@ name: Run tests
 on:
   push:
     branches: [ "master" ]
+    paths: &python-paths
+      - '**/*.py'
+      - '**/*.pyi'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - '.github/workflows/tests.yml'
   pull_request:
     branches: [ "master" ]
+    paths: *python-paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `paths:` filters so the heavy CI workflows only run when python-relevant files change. Docs-only or config-only PRs (markdown, unrelated files) no longer spin up the pytest matrix, ruff, stub generation, or the Sonar scan.

### Changes
- **`tests.yml`** and **`sonarcloud.yml`** — trigger only on `*.py`, `*.pyi`, `pyproject.toml`, `poetry.lock`, and the workflow's own file (plus `sonar-project.properties` for Sonar). `push` and `pull_request` share one list via a YAML anchor (`&python-paths` / `*python-paths`).
- **`codecov-gate.yml`** — count `*.pyi` as a python change too, keeping the gate's "is codecov expected?" decision aligned with when `tests.yml` uploads coverage.

### ⚠️ Branch-protection prerequisite
These checks must be **non-required** for this to be safe. A `paths`-filtered workflow that doesn't run leaves a *required* status check unreported, which blocks the PR indefinitely. Remove `linting`, `tests (ubuntu-latest, 3.11/3.12)`, and `SonarCloud Code Analysis` from the required-status list before/with merging this.

Untouched on purpose: `pr-title` (title-based, must always run), `clear-caches` (scheduled), `claude*` (comment/label-triggered).
