### PR TITLE
fix: handle empty inbox, image graphics, empty body and lazy login (#165)

### DIFF
--- a/src/smartschool/_objects.py
+++ b/src/smartschool/_objects.py
@@ -53,7 +53,7 @@ class ResultType(StrEnum):
 
 @dataclass(config=_config)
 class CourseGraphic:
-    type: Literal["icon"]
+    type: Literal["icon", "image"]
     value: String
 
 
@@ -395,7 +395,7 @@ class FullMessage:
     to: String | None
     subject: String
     date: DateTime
-    body: String
+    body: Annotated[String, BeforeValidator(lambda v: v or "")]  # a subject-only message has an empty (None) body
     status: int
     attachment: int
     unread: bool

--- a/src/smartschool/_session.py
+++ b/src/smartschool/_session.py
@@ -73,6 +73,16 @@ class Smartschool(Session, DevTracingMixin):
         else:
             self._authenticated_user_file.unlink(missing_ok=True)
 
+    def ensure_authenticated(self) -> None:
+        """
+        Make sure the session is logged in, triggering the lazy login when needed.
+
+        Handy before hitting an endpoint that answers unauthenticated requests with an
+        empty 200 instead of redirecting to ``/login`` (e.g. the XML message dispatcher),
+        where the transparent auth chain in :meth:`request` never fires.
+        """
+        _ = self.authenticated_user
+
     @property
     def _authenticated_user_file(self) -> Path | None:
         if self.creds:

--- a/src/smartschool/_xml_interface.py
+++ b/src/smartschool/_xml_interface.py
@@ -99,7 +99,7 @@ class SmartschoolXML(ABC, SessionMixin):
         # The XML dispatcher answers an empty 200 (not a login redirect) to an
         # unauthenticated session, so the transparent auth chain in
         # Session.request never fires. Force the lazy login before POSTing.
-        _ = self.session.authenticated_user
+        self.session.ensure_authenticated()
 
         response = self.session.post(
             self._url,

--- a/src/smartschool/_xml_interface.py
+++ b/src/smartschool/_xml_interface.py
@@ -96,6 +96,11 @@ class SmartschoolXML(ABC, SessionMixin):
         with contextlib.suppress(KeyError):
             return self._get_from_cache()
 
+        # The XML dispatcher answers an empty 200 (not a login redirect) to an
+        # unauthenticated session, so the transparent auth chain in
+        # Session.request never fires. Force the lazy login before POSTing.
+        _ = self.session.authenticated_user
+
         response = self.session.post(
             self._url,
             data={
@@ -106,21 +111,22 @@ class SmartschoolXML(ABC, SessionMixin):
             },
         )
 
-        root = ET.fromstring(response.text)
-
         all_entries = []
-        as_obj = self._object_to_instantiate
-        for el in root.findall(self._xpath):
-            as_dict = xml_to_dict(el)
-            self._post_process_element(as_dict)
+        text = response.text.strip()
+        if text:  # an empty body means an empty result set (e.g. an empty inbox)
+            root = ET.fromstring(text)
+            as_obj = self._object_to_instantiate
+            for el in root.findall(self._xpath):
+                as_dict = xml_to_dict(el)
+                self._post_process_element(as_dict)
 
-            if SessionMixin in as_obj.__mro__:
-                as_dict["session"] = self.session
+                if SessionMixin in as_obj.__mro__:
+                    as_dict["session"] = self.session
 
-            as_dict = _resolve_aliases(as_obj, as_dict)
-            obj = as_obj(**as_dict)
+                as_dict = _resolve_aliases(as_obj, as_dict)
+                obj = as_obj(**as_dict)
 
-            all_entries.append(obj)
+                all_entries.append(obj)
 
         self._store_into_cache(all_entries)
 

--- a/tests/messages_tests.py
+++ b/tests/messages_tests.py
@@ -93,11 +93,11 @@ def test_empty_inbox_returns_empty_iterator(session: Smartschool, requests_mock:
 
 def test_messages_force_authentication_before_posting(session: Smartschool, mocker: MockerFixture):
     """Issue #165: an unauthenticated session gets an empty 200 (no redirect), so the interface forces the lazy login before POSTing."""
-    auth = mocker.patch.object(type(session), "authenticated_user", new_callable=mocker.PropertyMock, return_value={"id": "x"})
+    ensure = mocker.patch.object(session, "ensure_authenticated")
 
     sut = list(MessageHeaders(session))
 
-    auth.assert_called()  # login was forced before the POST
+    ensure.assert_called_once()  # login was forced before the POST
     assert len(sut) == 2  # and the messages still parse afterwards
 
 

--- a/tests/messages_tests.py
+++ b/tests/messages_tests.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+from requests_mock import Mocker
+
 from smartschool import (
     AdjustMessageLabel,
     Attachments,
@@ -9,6 +14,8 @@ from smartschool import (
     MessageMoveToTrash,
     Smartschool,
 )
+
+_DISPATCHER_URL = "https://site/?module=Messages&file=dispatcher"
 
 
 def test_messages_happy_flow(session: Smartschool):
@@ -75,3 +82,31 @@ def test_trash_message_happy_flow(session: Smartschool):
     assert sut.msg_id == 123
     assert sut.box_type == "inbox"
     assert sut.is_deleted
+
+
+def test_empty_inbox_returns_empty_iterator(session: Smartschool, requests_mock: Mocker):
+    """Issue #165: an empty inbox returns an empty 200 body; iterate to nothing instead of raising ParseError."""
+    requests_mock.post(_DISPATCHER_URL, text="")
+
+    assert list(MessageHeaders(session)) == []
+
+
+def test_messages_force_authentication_before_posting(session: Smartschool, mocker: MockerFixture):
+    """Issue #165: an unauthenticated session gets an empty 200 (no redirect), so the interface forces the lazy login before POSTing."""
+    auth = mocker.patch.object(type(session), "authenticated_user", new_callable=mocker.PropertyMock, return_value={"id": "x"})
+
+    sut = list(MessageHeaders(session))
+
+    auth.assert_called()  # login was forced before the POST
+    assert len(sut) == 2  # and the messages still parse afterwards
+
+
+def test_message_with_empty_body_coerced_to_empty_string(session: Smartschool, requests_mock: Mocker):
+    """Issue #165: a message with a subject but no body has body=None in the XML; coerce it to ''."""
+    fixture = Path(__file__).parent / "requests/post/postboxes/show message.xml"
+    empty_body_xml = fixture.read_text(encoding="utf8").replace("<body>&lt;p&gt;Beste&lt;/p&gt;</body>", "<body/>")
+    requests_mock.post(_DISPATCHER_URL, text=empty_body_xml)
+
+    sut = Message(session, 123).get()
+
+    assert sut.body == ""

--- a/tests/objects_tests.py
+++ b/tests/objects_tests.py
@@ -36,3 +36,9 @@ def test_course_str_multiple_teachers(create_course):
 def test_course_str_no_teachers(create_course):
     course = create_course(0)
     assert str(course) == "Math (Teachers: )"
+
+
+def test_course_graphic_accepts_image():
+    """Issue #165: some schools use image graphics for courses, not only icons."""
+    assert CourseGraphic(type="image", value="foo").type == "image"
+    assert CourseGraphic(type="icon", value="foo").type == "icon"

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -77,6 +77,19 @@ class TestSmartschoolAuthentication:
         with pytest.raises(ValueError, match="Could not retrieve authenticated user information"):
             _ = session.authenticated_user
 
+    def test_ensure_authenticated_is_noop_when_already_logged_in(self, session):
+        """An already-authenticated session stays authenticated and does not raise."""
+        session.ensure_authenticated()
+
+        assert session._authenticated_user is not None
+
+    def test_ensure_authenticated_raises_when_login_fails(self, session):
+        """When the lazy login cannot establish a user, the failure surfaces."""
+        session._authenticated_user = None
+
+        with pytest.raises(ValueError, match="Could not retrieve authenticated user information"):
+            session.ensure_authenticated()
+
     def test_authenticated_user_setter_with_data(self, session, authenticated_user_data):
         """Should save authenticated user data to file."""
         session.authenticated_user = authenticated_user_data


### PR DESCRIPTION
Fixes the four issues reported in #165 (Flemish primary-school co-account, v0.9.0).

### 1. Empty inbox raised `ParseError`
`MessageHeaders` on an empty inbox got an empty 200 body, and `ET.fromstring("")` raised `no element found: line 1, column 0`. An empty body is now treated as an empty result set — the iterator yields nothing.

### 2. Course/Result `graphic.type` only accepted `"icon"`
Schools that use images for courses emit `graphic.type == "image"`, which failed validation on every `Courses()` / `Results()` call. `CourseGraphic.type` is widened to `Literal["icon", "image"]`.

### 3. Message body could be `None`
A message with a subject but no body carries `body=None` in the XML, failing `FullMessage` validation. The body is now coerced to `""`.

### 4. Messages endpoint did not trigger the lazy login
The XML dispatcher answers an empty 200 to an unauthenticated session instead of redirecting to `/login`, so the transparent auth chain in `Session.request` never fired (and you'd hit issue 1). The XML interface now forces the lazy login (`session.authenticated_user`) before POSTing — the same effect as the reporter's `session.get("/")` workaround, but automatic.

### Tests
Regression tests added for each: empty-inbox iterator, image graphic, empty-body coercion, and forced-authentication-before-POST. Full suite green (292 passed).

Closes #165