### PR TITLE
feat(messages): support sending to co-accounts (parents)

### DIFF
--- a/.github/workflows/codecov-gate.yml
+++ b/.github/workflows/codecov-gate.yml
@@ -3,23 +3,22 @@ name: Codecov gate
 # Posts a ``codecov-reported`` commit status that:
 #   - flips to *pending* (yellow) when a PR is opened or pushed to,
 #   - flips to *success* (green) once both ``codecov/project`` and
-#     ``codecov/patch`` check-runs have attached to the head commit.
+#     ``codecov/patch`` have reported on the head commit.
 #
 # It does NOT inspect whether the Codecov contexts themselves passed -
-# the codecov/* check-runs already surface that. The gate's only job is to
+# the codecov/* contexts already surface that. The gate's only job is to
 # prevent merging before Codecov has had a chance to weigh in. Add
 # ``codecov-reported`` to the required-status list in branch protection to
 # make the gate enforcing.
 #
-# Codecov reports via the Checks API, so the listener uses ``on: check_run``
-# (the legacy ``on: status`` would never fire). The gate itself stays a
-# *commit status* so it lines up with the other status-style required checks.
+# Codecov reports via commit *statuses* (not the Checks API) in this repo, so
+# the listener uses ``on: status`` and reads the statuses API. (An earlier
+# ``on: check_run`` listener never fired, leaving the gate stuck on pending.)
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  check_run:
-    types: [completed]
+  status: {}
 
 permissions:
   statuses: write
@@ -33,7 +32,7 @@ jobs:
     # test/coverage run (poetry.lock / pyproject.toml / *.py / the tests
     # workflow itself), pytest won't run and Codecov won't post - short-circuit
     # the gate to ``success`` so the PR isn't blocked forever. Otherwise post
-    # ``pending`` and wait for ``finalize``. No-op on check_run events.
+    # ``pending`` and wait for ``finalize``. No-op on status events.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -61,29 +60,32 @@ jobs:
             -f description="$desc"
 
   finalize:
-    # Re-fires on every check_run completion for the SHA. We only act when one
-    # of the two Codecov contexts is the trigger. Codecov posts via the Checks
-    # API (not legacy commit statuses), so ``on: status`` would never fire.
+    # Re-fires on every commit-status update. Act only when a Codecov context
+    # reports a final (non-pending) state. Codecov posts via commit statuses
+    # (not the Checks API), so we listen on ``status`` and read ``/status``.
+    # Our own ``codecov-reported`` posts also raise a status event, but the
+    # context filter below ignores them, so there is no feedback loop.
     if: |
-      github.event_name == 'check_run'
-      && (github.event.check_run.name == 'codecov/project' || github.event.check_run.name == 'codecov/patch')
+      github.event_name == 'status'
+      && (github.event.context == 'codecov/project' || github.event.context == 'codecov/patch')
+      && github.event.state != 'pending'
     runs-on: ubuntu-latest
     steps:
-      - name: Flip codecov-reported to success when both contexts have attached
+      - name: Flip codecov-reported to success when both contexts have reported
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.event.check_run.head_sha }}
+          SHA: ${{ github.event.sha }}
         run: |
           set -euo pipefail
-          json="$(gh api "/repos/${REPO}/commits/${SHA}/check-runs")"
-          have_project=$(echo "$json" | jq '[.check_runs[] | select(.name=="codecov/project")] | length')
-          have_patch=$(echo "$json"   | jq '[.check_runs[] | select(.name=="codecov/patch")]   | length')
+          json="$(gh api "/repos/${REPO}/commits/${SHA}/status")"
+          have_project=$(echo "$json" | jq '[.statuses[] | select(.context=="codecov/project" and .state!="pending")] | length')
+          have_patch=$(echo "$json"   | jq '[.statuses[] | select(.context=="codecov/patch"   and .state!="pending")] | length')
           if [ "$have_project" -gt 0 ] && [ "$have_patch" -gt 0 ]; then
             gh api -X POST "/repos/${REPO}/statuses/${SHA}" \
               -f state=success \
               -f context=codecov-reported \
               -f description="codecov has reported"
           else
-            echo "Only one codecov context attached so far - staying pending."
+            echo "Only one codecov context reported so far - staying pending."
           fi

--- a/.github/workflows/codecov-gate.yml
+++ b/.github/workflows/codecov-gate.yml
@@ -11,14 +11,18 @@ name: Codecov gate
 # ``codecov-reported`` to the required-status list in branch protection to
 # make the gate enforcing.
 #
-# Codecov reports via commit *statuses* (not the Checks API) in this repo, so
-# the listener uses ``on: status`` and reads the statuses API. (An earlier
-# ``on: check_run`` listener never fired, leaving the gate stuck on pending.)
+# Codecov may report via commit *statuses* or via the *Checks API* depending on
+# its configuration (this repo currently uses statuses). To be robust to either,
+# the listener triggers on both ``status`` and ``check_run`` and treats a Codecov
+# context as "reported" if it shows up in either API. (An earlier ``on: check_run``
+# only listener never fired here, leaving the gate stuck on pending.)
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
   status: {}
+  check_run:
+    types: [completed]
 
 permissions:
   statuses: write
@@ -32,7 +36,7 @@ jobs:
     # test/coverage run (poetry.lock / pyproject.toml / *.py / the tests
     # workflow itself), pytest won't run and Codecov won't post - short-circuit
     # the gate to ``success`` so the PR isn't blocked forever. Otherwise post
-    # ``pending`` and wait for ``finalize``. No-op on status events.
+    # ``pending`` and wait for ``finalize``. No-op on status/check_run events.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -60,32 +64,42 @@ jobs:
             -f description="$desc"
 
   finalize:
-    # Re-fires on every commit-status update. Act only when a Codecov context
-    # reports a final (non-pending) state. Codecov posts via commit statuses
-    # (not the Checks API), so we listen on ``status`` and read ``/status``.
-    # Our own ``codecov-reported`` posts also raise a status event, but the
-    # context filter below ignores them, so there is no feedback loop.
+    # Re-fires on every Codecov report, whether it arrives as a commit status or
+    # a check-run. A ``status`` event carries the context/state directly; a
+    # ``check_run: completed`` event carries the check name. Our own
+    # ``codecov-reported`` posts also raise a status event, but the context
+    # filter below ignores them, so there is no feedback loop.
     if: |
-      github.event_name == 'status'
-      && (github.event.context == 'codecov/project' || github.event.context == 'codecov/patch')
-      && github.event.state != 'pending'
+      (github.event_name == 'status'
+        && (github.event.context == 'codecov/project' || github.event.context == 'codecov/patch')
+        && github.event.state != 'pending')
+      || (github.event_name == 'check_run'
+        && (github.event.check_run.name == 'codecov/project' || github.event.check_run.name == 'codecov/patch'))
     runs-on: ubuntu-latest
     steps:
       - name: Flip codecov-reported to success when both contexts have reported
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          SHA: ${{ github.event.sha }}
+          # status event -> github.event.sha; check_run event -> the check's head_sha.
+          SHA: ${{ github.event.check_run.head_sha || github.event.sha }}
         run: |
           set -euo pipefail
-          json="$(gh api "/repos/${REPO}/commits/${SHA}/status")"
-          have_project=$(echo "$json" | jq '[.statuses[] | select(.context=="codecov/project" and .state!="pending")] | length')
-          have_patch=$(echo "$json"   | jq '[.statuses[] | select(.context=="codecov/patch"   and .state!="pending")] | length')
-          if [ "$have_project" -gt 0 ] && [ "$have_patch" -gt 0 ]; then
+          statuses="$(gh api "/repos/${REPO}/commits/${SHA}/status")"
+          checks="$(gh api "/repos/${REPO}/commits/${SHA}/check-runs")"
+          # A Codecov context counts as reported if it has a final (non-pending)
+          # result in EITHER API - so the gate works whichever way Codecov posts.
+          reported() {
+            local name="$1" in_status in_check
+            in_status=$(echo "$statuses" | jq --arg n "$name" '[.statuses[]  | select(.context==$n and .state!="pending")]      | length')
+            in_check=$(echo "$checks"    | jq --arg n "$name" '[.check_runs[] | select(.name==$n and .conclusion!=null)]        | length')
+            [ "$in_status" -gt 0 ] || [ "$in_check" -gt 0 ]
+          }
+          if reported "codecov/project" && reported "codecov/patch"; then
             gh api -X POST "/repos/${REPO}/statuses/${SHA}" \
               -f state=success \
               -f context=codecov-reported \
               -f description="codecov has reported"
           else
-            echo "Only one codecov context reported so far - staying pending."
+            echo "Both codecov contexts have not reported yet - staying pending."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs/
 *.iml
 credentials.yml
 cookies.txt
+*.har
 dev/_captures/
 .coverage
 coverage.json

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -86,12 +86,12 @@ if groups:
 if users:
     form.add_all_coaccounts(users[0])
 
-# ...or add them yourself. Search co-accounts: the parents come back as extra users
-# sharing the student's userID/ssID, with user_lt 1, 2, ... add_recipient routes a
-# co-account to the co-account field automatically, so you still just pick TO/CC/BCC.
-parents, _ = form.search_users("John", coaccount=True)
-for parent in parents:
-    form.add_recipient(parent, RecipientType.TO)
+# ...or add them yourself. get_coaccounts() returns just this student's co-accounts;
+# add_recipient routes a co-account to the co-account field automatically, so you still
+# only pick TO/CC/BCC.
+if users:
+    for parent in form.get_coaccounts(users[0]):
+        form.add_recipient(parent, RecipientType.TO)
 
 # Add attachments
 form.add_attachment("path/to/document.pdf")

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -82,6 +82,12 @@ if users:
 if groups:
     form.add_recipient(groups[0], RecipientType.CC)
 
+# Also message a student's co-accounts (parents). Search the co-account slot: the parents
+# come back as extra users sharing the student's userID/ssID, with user_lt 1, 2, ...
+parents, _ = form.search_users("John", RecipientType.COACCOUNT_TO)
+for parent in parents:
+    form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+
 # Add attachments
 form.add_attachment("path/to/document.pdf")
 form.add_attachment("path/to/image.png")
@@ -100,6 +106,11 @@ from smartschool import RecipientType
 RecipientType.TO    # To field
 RecipientType.CC    # Carbon copy
 RecipientType.BCC   # Blind carbon copy
+
+# Same three fields, but for the recipients' co-accounts (parents):
+RecipientType.COACCOUNT_TO
+RecipientType.COACCOUNT_CC
+RecipientType.COACCOUNT_BCC
 ```
 
 ### Searching Recipients
@@ -108,7 +119,7 @@ RecipientType.BCC   # Blind carbon copy
 # Search for recipients (users and groups)
 users, groups = form.search_users("search term")
 
-# Users have properties: userID, value (display name), ssID, coaccountname, classname, schoolname, picture
+# Users have properties: user_id, value (display name), ss_id, user_lt (0 = main account, 1+ = co-account), coaccountname, classname, schoolname, picture
 for user in users:
     print(f"User: {user.value}")
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -122,8 +122,8 @@ RecipientType.BCC   # Blind carbon copy
 # Search for recipients (users and groups)
 users, groups = form.search_users("search term")
 
-# Search a person's co-accounts (parents) instead of accounts
-coaccounts, _ = form.search_users("search term", coaccount=True)
+# Get a specific user's co-accounts (parents)
+coaccounts = form.get_coaccounts(users[0])
 
 # Users have properties: user_id, value (display name), ss_id, user_lt (0 = main account, 1+ = co-account), coaccountname, classname, schoolname, picture
 for user in users:

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -82,8 +82,12 @@ if users:
 if groups:
     form.add_recipient(groups[0], RecipientType.CC)
 
-# Also message a student's co-accounts (parents). Search the co-account slot: the parents
-# come back as extra users sharing the student's userID/ssID, with user_lt 1, 2, ...
+# Also message a student's co-accounts (parents) — one call adds all of them:
+if users:
+    form.add_all_coaccounts(users[0])
+
+# ...or add them yourself. Search the co-account slot: the parents come back as extra
+# users sharing the student's userID/ssID, with user_lt 1, 2, ...
 parents, _ = form.search_users("John", RecipientType.COACCOUNT_TO)
 for parent in parents:
     form.add_recipient(parent, RecipientType.COACCOUNT_TO)

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -86,11 +86,12 @@ if groups:
 if users:
     form.add_all_coaccounts(users[0])
 
-# ...or add them yourself. Search the co-account slot: the parents come back as extra
-# users sharing the student's userID/ssID, with user_lt 1, 2, ...
-parents, _ = form.search_users("John", RecipientType.COACCOUNT_TO)
+# ...or add them yourself. Search co-accounts: the parents come back as extra users
+# sharing the student's userID/ssID, with user_lt 1, 2, ... add_recipient routes a
+# co-account to the co-account field automatically, so you still just pick TO/CC/BCC.
+parents, _ = form.search_users("John", coaccount=True)
 for parent in parents:
-    form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+    form.add_recipient(parent, RecipientType.TO)
 
 # Add attachments
 form.add_attachment("path/to/document.pdf")
@@ -111,10 +112,8 @@ RecipientType.TO    # To field
 RecipientType.CC    # Carbon copy
 RecipientType.BCC   # Blind carbon copy
 
-# Same three fields, but for the recipients' co-accounts (parents):
-RecipientType.COACCOUNT_TO
-RecipientType.COACCOUNT_CC
-RecipientType.COACCOUNT_BCC
+# Co-accounts (parents) use the same three fields — a recipient with user_lt > 0 is routed
+# to the co-account block automatically, so there's no separate co-account recipient type.
 ```
 
 ### Searching Recipients
@@ -122,6 +121,9 @@ RecipientType.COACCOUNT_BCC
 ```python
 # Search for recipients (users and groups)
 users, groups = form.search_users("search term")
+
+# Search a person's co-accounts (parents) instead of accounts
+coaccounts, _ = form.search_users("search term", coaccount=True)
 
 # Users have properties: user_id, value (display name), ss_id, user_lt (0 = main account, 1+ = co-account), coaccountname, classname, schoolname, picture
 for user in users:

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -82,8 +82,9 @@ if users:
 if groups:
     form.add_recipient(groups[0], RecipientType.CC)
 
-# Also message a student's co-accounts (parents) — one call adds all of them:
-if users:
+# Messaging co-accounts (parents) is a staff/school-gated feature; check first:
+if form.can_send_to_coaccounts and users:
+    # one call adds every co-account of the student (or add_all_coaccounts(*users) for many):
     form.add_all_coaccounts(users[0])
 
 # ...or add them yourself. get_coaccounts() returns just this student's co-accounts;

--- a/src/smartschool/__init__.py
+++ b/src/smartschool/__init__.py
@@ -21,6 +21,7 @@ from ._credentials import AppCredentials, Credentials, EnvCredentials, PathCrede
 from ._exceptions import (
     SmartSchoolAttachmentUploadError,
     SmartSchoolAuthenticationError,
+    SmartSchoolCoAccountsUnavailableError,
     SmartSchoolDownloadError,
     SmartSchoolException,
     SmartSchoolJsonError,
@@ -182,6 +183,7 @@ __all__ = [
     "SkoreWorkYear",
     "SmartSchoolAttachmentUploadError",
     "SmartSchoolAuthenticationError",
+    "SmartSchoolCoAccountsUnavailableError",
     "SmartSchoolDownloadError",
     "SmartSchoolException",
     "SmartSchoolJsonError",

--- a/src/smartschool/_common.py
+++ b/src/smartschool/_common.py
@@ -35,6 +35,7 @@ __all__ = [
     "natural_sort",
     "parse_mime_type",
     "parse_size",
+    "parse_smsc_vars",
     "save",
     "send_email",
     "xml_to_dict",
@@ -150,6 +151,31 @@ def bs4_html(html: str | bytes | Response) -> BeautifulSoup:
         return BeautifulSoup(html, features="lxml")
 
     return BeautifulSoup(html, features="html.parser")
+
+
+def parse_smsc_vars(text: str) -> dict:
+    """
+    Extract the ``SMSC`` ``vars`` config object embedded in a Smartschool page or script.
+
+    Smartschool serializes it in two forms, both handled here:
+    - ``$.extend(true, SMSC, { vars : {...} })`` - a raw object literal;
+    - ``$.extend(..., JSON.parse('...'))`` - JS-string-escaped JSON wrapping a ``"vars"`` key.
+
+    Returns ``{}`` when the config is absent or unparseable.
+    """
+    if match := re.search(r"SMSC\s*,\s*\{\s*vars\s*:\s*", text):
+        with contextlib.suppress(json.JSONDecodeError):
+            return json.JSONDecoder().raw_decode(text, match.end())[0]
+
+    if match := re.search(r"JSON\s*\.\s*parse\s*\(\s*'(.*)'\s*\)\s*\)\s*;?\s*$", text, flags=re.IGNORECASE):
+        unescaped = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), match.group(1))
+        # dict() raises on any non-mapping shape (data not subscriptable, "vars" absent or not
+        # a mapping), collapsing all malformed payloads into the {} fallback below.
+        with contextlib.suppress(json.JSONDecodeError, TypeError, KeyError):
+            data = json.loads(unescaped.replace("\\\\", "\\"))
+            return dict(data["vars"])
+
+    return {}
 
 
 def _resolve_select_value(select_tag) -> tuple[list[str], str | list[str] | None]:

--- a/src/smartschool/_common.py
+++ b/src/smartschool/_common.py
@@ -167,9 +167,10 @@ def parse_smsc_vars(text: str) -> dict:
         with contextlib.suppress(json.JSONDecodeError):
             return json.JSONDecoder().raw_decode(text, match.end())[0]
 
-    # [^']* keeps the scan linear (S8786): a JS single-quoted string cannot contain a raw
-    # quote, so this matches exactly the string literal without backtracking.
-    if match := re.search(r"JSON\s*\.\s*parse\s*\(\s*'([^']*)'\s*\)\s*\)\s*;?\s*$", text, flags=re.IGNORECASE):
+    # Linear-scan pattern (S8786): [^']* cannot trade with the closing quote (a JS
+    # single-quoted string cannot contain a raw quote), and (?:;\s*)? keeps the trailing
+    # whitespace runs separated so no two quantifiers compete for the same characters.
+    if match := re.search(r"JSON\s*\.\s*parse\s*\(\s*'([^']*)'\s*\)\s*\)\s*(?:;\s*)?$", text, flags=re.IGNORECASE):
         unescaped = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), match.group(1))
         # dict() raises on any non-mapping shape (data not subscriptable, "vars" absent or not
         # a mapping), collapsing all malformed payloads into the {} fallback below.

--- a/src/smartschool/_common.py
+++ b/src/smartschool/_common.py
@@ -167,7 +167,9 @@ def parse_smsc_vars(text: str) -> dict:
         with contextlib.suppress(json.JSONDecodeError):
             return json.JSONDecoder().raw_decode(text, match.end())[0]
 
-    if match := re.search(r"JSON\s*\.\s*parse\s*\(\s*'(.*)'\s*\)\s*\)\s*;?\s*$", text, flags=re.IGNORECASE):
+    # [^']* keeps the scan linear (S8786): a JS single-quoted string cannot contain a raw
+    # quote, so this matches exactly the string literal without backtracking.
+    if match := re.search(r"JSON\s*\.\s*parse\s*\(\s*'([^']*)'\s*\)\s*\)\s*;?\s*$", text, flags=re.IGNORECASE):
         unescaped = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), match.group(1))
         # dict() raises on any non-mapping shape (data not subscriptable, "vars" absent or not
         # a mapping), collapsing all malformed payloads into the {} fallback below.

--- a/src/smartschool/_exceptions.py
+++ b/src/smartschool/_exceptions.py
@@ -19,6 +19,9 @@ class SmartSchoolException(Exception):
 
     message: str
 
+    def __str__(self) -> str:
+        return self.message
+
 
 class SmartSchoolAuthenticationError(SmartSchoolException):
     """Indicates an error during the authentication process."""
@@ -32,14 +35,11 @@ class SmartSchoolAttachmentUploadError(SmartSchoolException):
     """Indicates an error while uploading a message attachment."""
 
 
+@dataclass
 class SmartSchoolCoAccountsUnavailableError(SmartSchoolException):
     """Raised when co-accounts (parents) are used on an account that lacks that capability."""
 
-    def __init__(self, message: str = "This account cannot message co-accounts"):
-        super().__init__(message)
-
-    def __str__(self) -> str:
-        return self.message
+    message: str = "This account cannot message co-accounts"
 
 
 @dataclass

--- a/src/smartschool/_exceptions.py
+++ b/src/smartschool/_exceptions.py
@@ -1,6 +1,7 @@
 __all__ = [
     "SmartSchoolAttachmentUploadError",
     "SmartSchoolAuthenticationError",
+    "SmartSchoolCoAccountsUnavailableError",
     "SmartSchoolDownloadError",
     "SmartSchoolException",
     "SmartSchoolJsonError",
@@ -29,6 +30,10 @@ class SmartSchoolParsingError(SmartSchoolException):
 
 class SmartSchoolAttachmentUploadError(SmartSchoolException):
     """Indicates an error while uploading a message attachment."""
+
+
+class SmartSchoolCoAccountsUnavailableError(SmartSchoolException):
+    """Raised when co-accounts (parents) are used on an account that lacks that capability."""
 
 
 @dataclass

--- a/src/smartschool/_exceptions.py
+++ b/src/smartschool/_exceptions.py
@@ -35,6 +35,12 @@ class SmartSchoolAttachmentUploadError(SmartSchoolException):
 class SmartSchoolCoAccountsUnavailableError(SmartSchoolException):
     """Raised when co-accounts (parents) are used on an account that lacks that capability."""
 
+    def __init__(self, message: str = "This account cannot message co-accounts"):
+        super().__init__(message)
+
+    def __str__(self) -> str:
+        return self.message
+
 
 @dataclass
 class SmartSchoolDownloadError(SmartSchoolException):

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 from ._common import bs4_html
-from ._exceptions import SmartSchoolAttachmentUploadError
+from ._exceptions import SmartSchoolAttachmentUploadError, SmartSchoolCoAccountsUnavailableError
 from ._messages import BoxType
 from ._objects import MessageSearchGroup, MessageSearchUser
 from ._session import SessionMixin
@@ -246,6 +246,7 @@ class MessageComposerForm(SessionMixin):
             user_lt = getattr(recipient, "user_lt", 0)
 
         if user_lt > 0:  # a co-account -> mirrored co-account container of the chosen field
+            self._ensure_coaccounts_available()
             container = _COACCOUNT_FIELD[recipient_type]
             parent_node_id = f"insertSearchFieldContainer_{container}_0"
         else:
@@ -274,9 +275,20 @@ class MessageComposerForm(SessionMixin):
         narrows the co-account search to the ones that actually belong to ``user`` (same
         ``user_id``/``ss_id``). Add them with :meth:`add_recipient` - they are routed to the
         co-account field automatically.
+
+        Raises :class:`SmartSchoolCoAccountsUnavailableError` if this account cannot message
+        co-accounts (check :attr:`can_send_to_coaccounts` to avoid it). Failing up front matters:
+        a non-capable account's search comes back empty, so a later guard would never fire and
+        the message would silently go out without the parents.
         """
+        self._ensure_coaccounts_available()
         found, _ = self._search_recipients(user.value, coaccount=True)
         return [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id]
+
+    def _ensure_coaccounts_available(self) -> None:
+        """Guard every co-account path: raise if this account cannot message co-accounts."""
+        if not self.can_send_to_coaccounts:
+            raise SmartSchoolCoAccountsUnavailableError("This account cannot message co-accounts (canSendToCoAccounts is false).")
 
     def add_all_coaccounts(
         self,

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import json
 import mimetypes
-import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
-from ._common import bs4_html
+from logprise import logger
+
+from ._common import bs4_html, parse_smsc_vars
 from ._exceptions import SmartSchoolAttachmentUploadError, SmartSchoolCoAccountsUnavailableError
 from ._messages import BoxType
 from ._objects import MessageSearchGroup, MessageSearchUser
@@ -40,13 +40,18 @@ class RecipientType(Enum):
     BCC = "3"
 
     @property
+    def coaccount_container(self) -> str:
+        """The container index of this field's mirrored co-account block."""
+        return {RecipientType.TO: "1", RecipientType.CC: "4", RecipientType.BCC: "5"}[self]
+
+    @property
     def parent_node_id(self) -> str:
-        return f"insertSearchFieldContainer_{self.value}_0"
+        return _node_id(self.value)
 
 
-# The compose form mirrors each To/Cc/Bcc field into a second block for co-accounts (parents),
-# with these container indices.
-_COACCOUNT_FIELD = {RecipientType.TO: "1", RecipientType.CC: "4", RecipientType.BCC: "5"}
+def _node_id(container: str) -> str:
+    """The DOM id of a search-field container."""
+    return f"insertSearchFieldContainer_{container}_0"
 
 
 @dataclass
@@ -103,9 +108,12 @@ class MessageComposerForm(SessionMixin):
         soup = bs4_html(resp)
         self.hidden_fields = {inp["name"]: inp.get("value", "") for inp in soup.select("input[type=hidden][name]")}
         # The compose page always renders the co-account recipient block, so its presence is not
-        # a capability signal. The real (staff/school-gated) flag lives in the embedded SMSC.vars
-        # config object, which we parse as JSON.
-        self.can_send_to_coaccounts = bool(self._compose_vars(resp.text).get("canSendToCoAccounts"))
+        # a capability signal. The real (staff/school-gated) flag lives in the embedded SMSC vars
+        # config object.
+        smsc_vars = parse_smsc_vars(resp.text)
+        if not smsc_vars:
+            logger.warning("No SMSC vars config found in the compose page; assuming co-accounts are unavailable.")
+        self.can_send_to_coaccounts = bool(smsc_vars.get("canSendToCoAccounts"))
 
         self.payload = {
             "module": "Messages",
@@ -132,17 +140,6 @@ class MessageComposerForm(SessionMixin):
             "message": "",
             "bcc": "0",
         }
-
-    @staticmethod
-    def _compose_vars(html: str) -> dict:
-        """Return the ``SMSC.vars`` config object embedded in the compose page (``{}`` if absent/unparseable)."""
-        match = re.search(r"SMSC\s*,\s*\{\s*vars\s*:\s*", html)
-        if not match:
-            return {}
-        try:
-            return json.JSONDecoder().raw_decode(html, match.end())[0]
-        except json.JSONDecodeError:
-            return {}
 
     def set_field(self, key: str, value: str | int) -> None:
         self.payload[key] = str(value)
@@ -178,7 +175,7 @@ class MessageComposerForm(SessionMixin):
         # picked result is placed later by add_recipient() using its own ids -- so there's no
         # field to thread through here, only the coaccount flag.
         search_type = "1" if coaccount else "0"
-        parent_node_id = f"insertSearchFieldContainer_{search_type}_0"
+        parent_node_id = _node_id(search_type)
         response = self.session.post(
             "/?module=Messages&file=searchUsers",
             data={
@@ -251,20 +248,21 @@ class MessageComposerForm(SessionMixin):
         if isinstance(recipient, MessageSearchUser):
             recipient_id = recipient.user_id
             type_id = "users"
+            default_lt = recipient.user_lt
         else:
             recipient_id = recipient.group_id
             type_id = "groups"
+            default_lt = 0  # groups have no co-accounts
 
         if user_lt is None:
-            user_lt = getattr(recipient, "user_lt", 0)
+            user_lt = default_lt
 
         if user_lt > 0:  # a co-account -> mirrored co-account container of the chosen field
             self._ensure_coaccounts_available()
-            container = _COACCOUNT_FIELD[recipient_type]
-            parent_node_id = f"insertSearchFieldContainer_{container}_0"
+            container = recipient_type.coaccount_container
         else:
             container = recipient_type.value
-            parent_node_id = recipient_type.parent_node_id
+        parent_node_id = _node_id(container)
 
         response = self.session.post(
             "/?module=Messages&file=searchUsers&function=addUserToSelected",

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import mimetypes
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -74,6 +75,9 @@ class MessageComposerForm(SessionMixin):
     msg_id: str = "undefined"
     payload: dict[str, str] = field(default_factory=dict)
     hidden_fields: dict[str, str] = field(default_factory=dict)
+    # Whether this account may message co-accounts (parents); set from the compose page by
+    # refresh(). Co-account calls only work when this is True. See :meth:`add_all_coaccounts`.
+    can_send_to_coaccounts: bool = False
 
     @classmethod
     def create(
@@ -97,6 +101,9 @@ class MessageComposerForm(SessionMixin):
 
         soup = bs4_html(resp)
         self.hidden_fields = {inp["name"]: inp.get("value", "") for inp in soup.select("input[type=hidden][name]")}
+        # The compose page embeds this flag; the co-account recipient block is always rendered,
+        # so this is the real capability signal (staff/school-gated), not the block's presence.
+        self.can_send_to_coaccounts = bool(re.search(r'"canSendToCoAccounts"\s*:\s*true', resp.text))
 
         self.payload = {
             "module": "Messages",

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -26,27 +26,33 @@ __all__ = [
 
 class RecipientType(Enum):
     """
-    Recipient slot in the compose form.
+    Recipient field of the compose form (To / Cc / Bcc).
 
-    The form has two blocks: one for the accounts themselves (``TO``/``CC``/``BCC``) and one
-    for their co-accounts / parents (``COACCOUNT_TO``/``COACCOUNT_CC``/``COACCOUNT_BCC``). The
-    value is the search-field container index Smartschool assigns to each slot.
+    The value is the search-field container index Smartschool assigns to the field. Co-accounts
+    (parents) live in a mirrored block of containers; the composer routes a recipient there
+    automatically when it is a co-account (``user_lt`` > 0), so callers only pick To/Cc/Bcc.
     """
 
     TO = "0"
     CC = "2"
     BCC = "3"
-    COACCOUNT_TO = "1"
-    COACCOUNT_CC = "4"
-    COACCOUNT_BCC = "5"
 
     @property
     def parent_node_id(self) -> str:
         return f"insertSearchFieldContainer_{self.value}_0"
 
-    @property
-    def is_coaccount(self) -> bool:
-        return self in (RecipientType.COACCOUNT_TO, RecipientType.COACCOUNT_CC, RecipientType.COACCOUNT_BCC)
+
+# The compose form mirrors each To/Cc/Bcc field into a second block for co-accounts (parents),
+# with these container indices.
+_COACCOUNT_FIELD = {RecipientType.TO: "1", RecipientType.CC: "4", RecipientType.BCC: "5"}
+
+
+def _field_ids(recipient_type: RecipientType, *, coaccount: bool) -> tuple[str, str]:
+    """Return the ``(type, parentNodeId)`` request fields for a recipient field."""
+    if coaccount:
+        container = _COACCOUNT_FIELD[recipient_type]
+        return container, f"insertSearchFieldContainer_{container}_0"
+    return recipient_type.value, recipient_type.parent_node_id
 
 
 @dataclass
@@ -138,24 +144,28 @@ class MessageComposerForm(SessionMixin):
     def search_users(
         self,
         search_text: str,
-        recipient_type: RecipientType = RecipientType.TO,
+        *,
+        coaccount: bool = False,
     ) -> tuple[list[MessageSearchUser], list[MessageSearchGroup]]:
         """
-        Search recipients for the given slot.
+        Search recipients.
 
-        Search a ``COACCOUNT_*`` slot to find a student's co-accounts (parents): they come
-        back as extra users sharing the student's ``user_id``/``ss_id`` with ``user_lt`` >= 1.
+        With ``coaccount=True`` the search returns co-accounts (parents) instead of accounts:
+        each comes back as a user sharing the account's ``user_id``/``ss_id`` with ``user_lt``
+        >= 1. Add them with :meth:`add_recipient` as usual - they are routed to the co-account
+        field automatically.
         """
         unique_usc = self.payload.get("uniqueUsc", "")
         if not unique_usc:
             raise ValueError("uniqueUsc is missing. Call refresh() or create() before searching users.")
 
+        search_type, parent_node_id = _field_ids(RecipientType.TO, coaccount=coaccount)
         response = self.session.post(
             "/?module=Messages&file=searchUsers",
             data={
                 "val": search_text,
-                "type": recipient_type.value,
-                "parentNodeId": recipient_type.parent_node_id,
+                "type": search_type,
+                "parentNodeId": parent_node_id,
                 "xml": "<results></results>",
                 "uniqueUsc": unique_usc,
             },
@@ -204,11 +214,12 @@ class MessageComposerForm(SessionMixin):
         user_lt: int | None = None,
     ) -> None:
         """
-        Add a recipient to the given slot.
+        Add a recipient to the given field (To/Cc/Bcc).
 
         ``user_lt`` defaults to the recipient's own ``user_lt`` (0 for a main account or a
         group, 1+ for a co-account), so a co-account returned by :meth:`search_users` is added
-        correctly without passing it explicitly. Pass it to override.
+        correctly without passing it explicitly. Pass it to override. A co-account (resolved
+        ``user_lt`` > 0) is routed to the co-account block of the chosen field automatically.
         """
         unique_usc = self.payload.get("uniqueUsc", "")
         if not unique_usc:
@@ -225,13 +236,14 @@ class MessageComposerForm(SessionMixin):
         if user_lt is None:
             user_lt = getattr(recipient, "user_lt", 0)
 
+        add_type, parent_node_id = _field_ids(recipient_type, coaccount=user_lt > 0)
         response = self.session.post(
             "/?module=Messages&file=searchUsers&function=addUserToSelected",
             data={
                 "id": str(recipient_id),
                 "typeId": type_id,
-                "type": recipient_type.value,
-                "parentNodeId": recipient_type.parent_node_id,
+                "type": add_type,
+                "parentNodeId": parent_node_id,
                 "ssid": str(ssid),
                 "userlt": str(user_lt),
                 "uniqueUsc": unique_usc,
@@ -242,19 +254,16 @@ class MessageComposerForm(SessionMixin):
     def add_all_coaccounts(
         self,
         user: MessageSearchUser,
-        recipient_type: RecipientType = RecipientType.COACCOUNT_TO,
+        recipient_type: RecipientType = RecipientType.TO,
     ) -> list[MessageSearchUser]:
         """
         Add every co-account (typically the parents) of ``user`` as recipients.
 
-        Searches the co-account slot for ``user`` and adds each co-account belonging to them,
-        returning the co-accounts added (empty if the account has none). ``recipient_type``
-        must be one of the ``COACCOUNT_*`` slots (defaults to the co-account To field).
+        Searches the co-accounts for ``user`` and adds each one belonging to them, returning the
+        co-accounts added (empty if the account has none). ``recipient_type`` picks the field
+        (To/Cc/Bcc); the co-account routing is handled automatically.
         """
-        if not recipient_type.is_coaccount:
-            raise ValueError(f"add_all_coaccounts needs a COACCOUNT_* recipient type, got {recipient_type.name}.")
-
-        found, _ = self.search_users(user.value, recipient_type)
+        found, _ = self.search_users(user.value, coaccount=True)
         coaccounts = [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id and c.user_lt > 0]
         for coaccount in coaccounts:
             self.add_recipient(coaccount, recipient_type)

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -256,6 +256,18 @@ class MessageComposerForm(SessionMixin):
         )
         response.raise_for_status()
 
+    def get_coaccounts(self, user: MessageSearchUser) -> list[MessageSearchUser]:
+        """
+        Return the co-accounts (typically the parents) of ``user``.
+
+        Co-accounts are discovered through a name search, which can also surface namesakes and
+        the account itself, so this narrows the results to the ones that actually belong to
+        ``user`` (same ``user_id``/``ss_id``, ``user_lt`` >= 1). Add them with
+        :meth:`add_recipient` - they are routed to the co-account field automatically.
+        """
+        found, _ = self.search_users(user.value, coaccount=True)
+        return [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id and c.user_lt > 0]
+
     def add_all_coaccounts(
         self,
         user: MessageSearchUser,
@@ -264,12 +276,10 @@ class MessageComposerForm(SessionMixin):
         """
         Add every co-account (typically the parents) of ``user`` as recipients.
 
-        Searches the co-accounts for ``user`` and adds each one belonging to them, returning the
-        co-accounts added (empty if the account has none). ``recipient_type`` picks the field
-        (To/Cc/Bcc); the co-account routing is handled automatically.
+        Returns the co-accounts added (empty if the account has none). ``recipient_type`` picks
+        the field (To/Cc/Bcc); the co-account routing is handled automatically.
         """
-        found, _ = self.search_users(user.value, coaccount=True)
-        coaccounts = [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id and c.user_lt > 0]
+        coaccounts = self.get_coaccounts(user)
         for coaccount in coaccounts:
             self.add_recipient(coaccount, recipient_type)
         return coaccounts

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -159,11 +159,12 @@ class MessageComposerForm(SessionMixin):
         if not unique_usc:
             raise ValueError("uniqueUsc is missing. Call refresh() or create() before searching users.")
 
-        # The search field only selects accounts (container 0) vs co-accounts (container 1) --
-        # the To/Cc/Bcc choice doesn't change which people match (anyone can be To/Cc/Bcc), and
-        # a picked result is placed by add_recipient() using its own ids, not this field. So we
-        # always search the To slot; only the coaccount flag matters here.
-        search_type, parent_node_id = _field_ids(RecipientType.TO, coaccount=coaccount)
+        # Search only distinguishes accounts (container 0) from co-accounts (container 1). The
+        # To/Cc/Bcc field is irrelevant to which people match (anyone can be To/Cc/Bcc), and a
+        # picked result is placed later by add_recipient() using its own ids -- so there's no
+        # field to thread through here, only the coaccount flag.
+        search_type = "1" if coaccount else "0"
+        parent_node_id = f"insertSearchFieldContainer_{search_type}_0"
         response = self.session.post(
             "/?module=Messages&file=searchUsers",
             data={

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -275,19 +275,23 @@ class MessageComposerForm(SessionMixin):
 
     def add_all_coaccounts(
         self,
-        user: MessageSearchUser,
+        *users: MessageSearchUser,
         recipient_type: RecipientType = RecipientType.TO,
     ) -> list[MessageSearchUser]:
         """
-        Add every co-account (typically the parents) of ``user`` as recipients.
+        Add every co-account (typically the parents) of each user in ``users`` as recipients.
 
-        Returns the co-accounts added (empty if the account has none). ``recipient_type`` picks
+        Accepts one or more users (e.g. ``add_all_coaccounts(*students)``) and returns the
+        co-accounts added across all of them (empty if none have any). ``recipient_type`` picks
         the field (To/Cc/Bcc); the co-account routing is handled automatically.
         """
-        coaccounts = self.get_coaccounts(user)
-        for coaccount in coaccounts:
-            self.add_recipient(coaccount, recipient_type)
-        return coaccounts
+        added: list[MessageSearchUser] = []
+        for user in users:
+            coaccounts = self.get_coaccounts(user)
+            for coaccount in coaccounts:
+                self.add_recipient(coaccount, recipient_type)
+            added.extend(coaccounts)
+        return added
 
     def add_attachment(self, file_path: str | Path) -> None:
         upload_dir = self.payload.get("randomDir", "")

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -141,19 +141,21 @@ class MessageComposerForm(SessionMixin):
     def set_message_html(self, message_html: str) -> None:
         self.set_field("message", message_html)
 
-    def search_users(
+    def search_users(self, search_text: str) -> tuple[list[MessageSearchUser], list[MessageSearchGroup]]:
+        """Search accounts (users and groups) by name. For a user's co-accounts use :meth:`get_coaccounts`."""
+        return self._search_recipients(search_text, coaccount=False)
+
+    def _search_recipients(
         self,
         search_text: str,
         *,
-        coaccount: bool = False,
+        coaccount: bool,
     ) -> tuple[list[MessageSearchUser], list[MessageSearchGroup]]:
         """
-        Search recipients.
+        POST a recipient search and parse the result.
 
-        With ``coaccount=True`` the search returns co-accounts (parents) instead of accounts:
-        each comes back as a user sharing the account's ``user_id``/``ss_id`` with ``user_lt``
-        >= 1. Add them with :meth:`add_recipient` as usual - they are routed to the co-account
-        field automatically.
+        ``coaccount`` picks accounts (``False``) or co-accounts (``True``); a co-account search
+        returns only co-accounts (``user_lt`` >= 1).
         """
         unique_usc = self.payload.get("uniqueUsc", "")
         if not unique_usc:
@@ -210,6 +212,9 @@ class MessageComposerForm(SessionMixin):
                     ),
                 )
 
+        if coaccount:  # a co-account search must yield co-accounts, never the main accounts
+            users = [u for u in users if u.user_lt > 0]
+
         return users, groups
 
     def add_recipient(
@@ -260,13 +265,13 @@ class MessageComposerForm(SessionMixin):
         """
         Return the co-accounts (typically the parents) of ``user``.
 
-        Co-accounts are discovered through a name search, which can also surface namesakes and
-        the account itself, so this narrows the results to the ones that actually belong to
-        ``user`` (same ``user_id``/``ss_id``, ``user_lt`` >= 1). Add them with
-        :meth:`add_recipient` - they are routed to the co-account field automatically.
+        Co-accounts are discovered through a name search, which can span namesakes, so this
+        narrows the co-account search to the ones that actually belong to ``user`` (same
+        ``user_id``/``ss_id``). Add them with :meth:`add_recipient` - they are routed to the
+        co-account field automatically.
         """
-        found, _ = self.search_users(user.value, coaccount=True)
-        return [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id and c.user_lt > 0]
+        found, _ = self._search_recipients(user.value, coaccount=True)
+        return [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id]
 
     def add_all_coaccounts(
         self,

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -44,6 +44,10 @@ class RecipientType(Enum):
     def parent_node_id(self) -> str:
         return f"insertSearchFieldContainer_{self.value}_0"
 
+    @property
+    def is_coaccount(self) -> bool:
+        return self in (RecipientType.COACCOUNT_TO, RecipientType.COACCOUNT_CC, RecipientType.COACCOUNT_BCC)
+
 
 @dataclass
 class MessageComposerForm(SessionMixin):
@@ -59,10 +63,7 @@ class MessageComposerForm(SessionMixin):
     >>> form.set_message_html("<p>My message</p>")
     >>> users, groups = form.search_users("John")
     >>> form.add_recipient(users[0], RecipientType.TO)
-    >>> # also message that student's co-accounts (parents):
-    >>> parents, _ = form.search_users("John", RecipientType.COACCOUNT_TO)
-    >>> for parent in parents:
-    ...     form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+    >>> form.add_all_coaccounts(users[0])  # also message that student's co-accounts (parents)
     >>> form.add_attachment("README.md")
     >>> response = form.send()
     >>> print(response.status_code)
@@ -237,6 +238,27 @@ class MessageComposerForm(SessionMixin):
             },
         )
         response.raise_for_status()
+
+    def add_all_coaccounts(
+        self,
+        user: MessageSearchUser,
+        recipient_type: RecipientType = RecipientType.COACCOUNT_TO,
+    ) -> list[MessageSearchUser]:
+        """
+        Add every co-account (typically the parents) of ``user`` as recipients.
+
+        Searches the co-account slot for ``user`` and adds each co-account belonging to them,
+        returning the co-accounts added (empty if the account has none). ``recipient_type``
+        must be one of the ``COACCOUNT_*`` slots (defaults to the co-account To field).
+        """
+        if not recipient_type.is_coaccount:
+            raise ValueError(f"add_all_coaccounts needs a COACCOUNT_* recipient type, got {recipient_type.name}.")
+
+        found, _ = self.search_users(user.value, recipient_type)
+        coaccounts = [c for c in found if c.user_id == user.user_id and c.ss_id == user.ss_id and c.user_lt > 0]
+        for coaccount in coaccounts:
+            self.add_recipient(coaccount, recipient_type)
+        return coaccounts
 
     def add_attachment(self, file_path: str | Path) -> None:
         upload_dir = self.payload.get("randomDir", "")

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -159,6 +159,10 @@ class MessageComposerForm(SessionMixin):
         if not unique_usc:
             raise ValueError("uniqueUsc is missing. Call refresh() or create() before searching users.")
 
+        # The search field only selects accounts (container 0) vs co-accounts (container 1) --
+        # the To/Cc/Bcc choice doesn't change which people match (anyone can be To/Cc/Bcc), and
+        # a picked result is placed by add_recipient() using its own ids, not this field. So we
+        # always search the To slot; only the coaccount flag matters here.
         search_type, parent_node_id = _field_ids(RecipientType.TO, coaccount=coaccount)
         response = self.session.post(
             "/?module=Messages&file=searchUsers",

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -47,14 +47,6 @@ class RecipientType(Enum):
 _COACCOUNT_FIELD = {RecipientType.TO: "1", RecipientType.CC: "4", RecipientType.BCC: "5"}
 
 
-def _field_ids(recipient_type: RecipientType, *, coaccount: bool) -> tuple[str, str]:
-    """Return the ``(type, parentNodeId)`` request fields for a recipient field."""
-    if coaccount:
-        container = _COACCOUNT_FIELD[recipient_type]
-        return container, f"insertSearchFieldContainer_{container}_0"
-    return recipient_type.value, recipient_type.parent_node_id
-
-
 @dataclass
 class MessageComposerForm(SessionMixin):
     """
@@ -246,13 +238,19 @@ class MessageComposerForm(SessionMixin):
         if user_lt is None:
             user_lt = getattr(recipient, "user_lt", 0)
 
-        add_type, parent_node_id = _field_ids(recipient_type, coaccount=user_lt > 0)
+        if user_lt > 0:  # a co-account -> mirrored co-account container of the chosen field
+            container = _COACCOUNT_FIELD[recipient_type]
+            parent_node_id = f"insertSearchFieldContainer_{container}_0"
+        else:
+            container = recipient_type.value
+            parent_node_id = recipient_type.parent_node_id
+
         response = self.session.post(
             "/?module=Messages&file=searchUsers&function=addUserToSelected",
             data={
                 "id": str(recipient_id),
                 "typeId": type_id,
-                "type": add_type,
+                "type": container,
                 "parentNodeId": parent_node_id,
                 "ssid": str(ssid),
                 "userlt": str(user_lt),

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import mimetypes
 import re
 from dataclasses import dataclass, field
@@ -101,9 +102,10 @@ class MessageComposerForm(SessionMixin):
 
         soup = bs4_html(resp)
         self.hidden_fields = {inp["name"]: inp.get("value", "") for inp in soup.select("input[type=hidden][name]")}
-        # The compose page embeds this flag; the co-account recipient block is always rendered,
-        # so this is the real capability signal (staff/school-gated), not the block's presence.
-        self.can_send_to_coaccounts = bool(re.search(r'"canSendToCoAccounts"\s*:\s*true', resp.text))
+        # The compose page always renders the co-account recipient block, so its presence is not
+        # a capability signal. The real (staff/school-gated) flag lives in the embedded SMSC.vars
+        # config object, which we parse as JSON.
+        self.can_send_to_coaccounts = bool(self._compose_vars(resp.text).get("canSendToCoAccounts"))
 
         self.payload = {
             "module": "Messages",
@@ -130,6 +132,17 @@ class MessageComposerForm(SessionMixin):
             "message": "",
             "bcc": "0",
         }
+
+    @staticmethod
+    def _compose_vars(html: str) -> dict:
+        """Return the ``SMSC.vars`` config object embedded in the compose page (``{}`` if absent/unparseable)."""
+        match = re.search(r"SMSC\s*,\s*\{\s*vars\s*:\s*", html)
+        if not match:
+            return {}
+        try:
+            return json.JSONDecoder().raw_decode(html, match.end())[0]
+        except json.JSONDecodeError:
+            return {}
 
     def set_field(self, key: str, value: str | int) -> None:
         self.payload[key] = str(value)
@@ -288,7 +301,7 @@ class MessageComposerForm(SessionMixin):
     def _ensure_coaccounts_available(self) -> None:
         """Guard every co-account path: raise if this account cannot message co-accounts."""
         if not self.can_send_to_coaccounts:
-            raise SmartSchoolCoAccountsUnavailableError("This account cannot message co-accounts (canSendToCoAccounts is false).")
+            raise SmartSchoolCoAccountsUnavailableError
 
     def add_all_coaccounts(
         self,

--- a/src/smartschool/_message_composer.py
+++ b/src/smartschool/_message_composer.py
@@ -25,11 +25,20 @@ __all__ = [
 
 
 class RecipientType(Enum):
-    """Recipient type for message composition (TO, CC, BCC)."""
+    """
+    Recipient slot in the compose form.
+
+    The form has two blocks: one for the accounts themselves (``TO``/``CC``/``BCC``) and one
+    for their co-accounts / parents (``COACCOUNT_TO``/``COACCOUNT_CC``/``COACCOUNT_BCC``). The
+    value is the search-field container index Smartschool assigns to each slot.
+    """
 
     TO = "0"
     CC = "2"
     BCC = "3"
+    COACCOUNT_TO = "1"
+    COACCOUNT_CC = "4"
+    COACCOUNT_BCC = "5"
 
     @property
     def parent_node_id(self) -> str:
@@ -50,6 +59,10 @@ class MessageComposerForm(SessionMixin):
     >>> form.set_message_html("<p>My message</p>")
     >>> users, groups = form.search_users("John")
     >>> form.add_recipient(users[0], RecipientType.TO)
+    >>> # also message that student's co-accounts (parents):
+    >>> parents, _ = form.search_users("John", RecipientType.COACCOUNT_TO)
+    >>> for parent in parents:
+    ...     form.add_recipient(parent, RecipientType.COACCOUNT_TO)
     >>> form.add_attachment("README.md")
     >>> response = form.send()
     >>> print(response.status_code)
@@ -121,7 +134,17 @@ class MessageComposerForm(SessionMixin):
     def set_message_html(self, message_html: str) -> None:
         self.set_field("message", message_html)
 
-    def search_users(self, search_text: str) -> tuple[list[MessageSearchUser], list[MessageSearchGroup]]:
+    def search_users(
+        self,
+        search_text: str,
+        recipient_type: RecipientType = RecipientType.TO,
+    ) -> tuple[list[MessageSearchUser], list[MessageSearchGroup]]:
+        """
+        Search recipients for the given slot.
+
+        Search a ``COACCOUNT_*`` slot to find a student's co-accounts (parents): they come
+        back as extra users sharing the student's ``user_id``/``ss_id`` with ``user_lt`` >= 1.
+        """
         unique_usc = self.payload.get("uniqueUsc", "")
         if not unique_usc:
             raise ValueError("uniqueUsc is missing. Call refresh() or create() before searching users.")
@@ -130,8 +153,8 @@ class MessageComposerForm(SessionMixin):
             "/?module=Messages&file=searchUsers",
             data={
                 "val": search_text,
-                "type": "0",
-                "parentNodeId": "insertSearchFieldContainer_0_0",
+                "type": recipient_type.value,
+                "parentNodeId": recipient_type.parent_node_id,
                 "xml": "<results></results>",
                 "uniqueUsc": unique_usc,
             },
@@ -150,6 +173,7 @@ class MessageComposerForm(SessionMixin):
                         userID=int(user.findtext("userID", default="0")),
                         value=user.findtext("value", default=""),
                         ssID=int(user.findtext("ssID", default="0")),
+                        userLT=int(user.findtext("userLT", default="0")),
                         coaccountname=user.findtext("coaccountname") or None,
                         classname=user.findtext("classname") or None,
                         schoolname=user.findtext("schoolname") or None,
@@ -176,8 +200,15 @@ class MessageComposerForm(SessionMixin):
         self,
         recipient: MessageSearchUser | MessageSearchGroup,
         recipient_type: RecipientType = RecipientType.TO,
-        user_lt: int = 0,
+        user_lt: int | None = None,
     ) -> None:
+        """
+        Add a recipient to the given slot.
+
+        ``user_lt`` defaults to the recipient's own ``user_lt`` (0 for a main account or a
+        group, 1+ for a co-account), so a co-account returned by :meth:`search_users` is added
+        correctly without passing it explicitly. Pass it to override.
+        """
         unique_usc = self.payload.get("uniqueUsc", "")
         if not unique_usc:
             raise ValueError("uniqueUsc is missing. Call refresh() or create() before adding recipients.")
@@ -189,6 +220,9 @@ class MessageComposerForm(SessionMixin):
         else:
             recipient_id = recipient.group_id
             type_id = "groups"
+
+        if user_lt is None:
+            user_lt = getattr(recipient, "user_lt", 0)
 
         response = self.session.post(
             "/?module=Messages&file=searchUsers&function=addUserToSelected",

--- a/src/smartschool/_objects.py
+++ b/src/smartschool/_objects.py
@@ -445,6 +445,9 @@ class MessageSearchUser:
     user_id: Annotated[int, Field(validation_alias="userID")]
     value: String
     ss_id: Annotated[int, Field(validation_alias="ssID")]
+    # 0 = the account itself; 1, 2, ... = its co-accounts (parents). Co-accounts reuse the
+    # account's user_id/ss_id and are told apart by this index.
+    user_lt: Annotated[int, Field(validation_alias="userLT")] = 0
     coaccountname: String | None = None
     classname: String | None = None
     schoolname: String | None = None

--- a/src/smartschool/_session.py
+++ b/src/smartschool/_session.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import re
 from dataclasses import dataclass, field
 from functools import cached_property
 from http.cookiejar import LoadError, LWPCookieJar
@@ -14,7 +13,7 @@ import yaml
 from logprise import logger
 from requests import Session
 
-from ._common import bs4_html, fill_form
+from ._common import bs4_html, fill_form, parse_smsc_vars
 from ._dev_tracing import DevTracingMixin
 from ._exceptions import SmartSchoolAuthenticationError, SmartSchoolDownloadError, SmartSchoolJsonError
 
@@ -260,12 +259,10 @@ class Smartschool(Session, DevTracingMixin):
             if script.get("src") or "extend" not in script.text:
                 continue
 
-            if match := re.search(r"JSON\s*\.\s*parse\s*\(\s*'(.*)'\s*\)\s*\)\s*;?\s*$", script.text, flags=re.IGNORECASE):
-                result = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), match.group(1))
-                data = json.loads(result.replace("\\\\", "\\"))
-                with contextlib.suppress(KeyError, TypeError, IndexError):
-                    self.authenticated_user = data["vars"]["authenticatedUser"]
-                    return
+            smsc_vars = parse_smsc_vars(script.text)
+            if "authenticatedUser" in smsc_vars:
+                self.authenticated_user = smsc_vars["authenticatedUser"]
+                return
 
     @cached_property
     def _url(self) -> str:

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -177,19 +177,34 @@ class TestMessageComposerFormRefresh:
         assert "msgID=789" in call_url
 
     def test_refresh_detects_coaccount_support(self, session: Smartschool):
-        # The compose fixture embeds "canSendToCoAccounts":true (a staff/school-gated account).
+        # The compose fixture embeds SMSC.vars with "canSendToCoAccounts":true (staff/school-gated).
         form = MessageComposerForm.create(session=session)
 
         assert form.can_send_to_coaccounts is True
 
-    def test_refresh_reports_no_coaccount_support_when_flag_is_false(self, session: Smartschool, requests_mock: Mocker):
+    def _refresh_with_compose_html(self, session: Smartschool, requests_mock: Mocker, html: str) -> MessageComposerForm:
         form = MessageComposerForm(session=session)
         requests_mock.get(
             "https://site/?module=Messages&file=composeMessage&boxType=inbox&composeType=0&msgID=undefined",
-            text='<html><script>var cfg={"canSendToCoAccounts":false};</script></html>',
+            text=html,
         )
-
         form.refresh()
+        return form
+
+    def test_refresh_no_support_when_flag_is_false(self, session: Smartschool, requests_mock: Mocker):
+        html = '<script>$.extend(true, SMSC, { vars : {"canSendToCoAccounts":false} });</script>'
+        form = self._refresh_with_compose_html(session, requests_mock, html)
+
+        assert form.can_send_to_coaccounts is False
+
+    def test_refresh_no_support_when_config_absent(self, session: Smartschool, requests_mock: Mocker):
+        form = self._refresh_with_compose_html(session, requests_mock, "<html><body>no config here</body></html>")
+
+        assert form.can_send_to_coaccounts is False
+
+    def test_refresh_no_support_when_config_is_malformed(self, session: Smartschool, requests_mock: Mocker):
+        html = '<script>$.extend(true, SMSC, { vars : {"canSendToCoAccounts": tru</script>'  # truncated JSON
+        form = self._refresh_with_compose_html(session, requests_mock, html)
 
         assert form.can_send_to_coaccounts is False
 

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -20,6 +20,40 @@ if TYPE_CHECKING:
 
     from smartschool import Smartschool
 
+# Anonymized co-account search response: a student ("Robin Doe", userID 111 / ssID 222)
+# with two co-accounts (parents). They reuse the student's userID/ssID and are told apart
+# by <userLT> (0 = the student's own account, 1 = first co-account, 2 = second).
+_COACCOUNT_SEARCH_XML = """<results>
+<type>1</type>
+<ssID>222</ssID>
+<parentNodeId>insertSearchFieldContainer_1_0</parentNodeId>
+<groups />
+<users>
+<user>
+<userID>111</userID>
+<text>Robin Doe</text>
+<value>Robin Doe</value>
+<selectable>on</selectable>
+<ssID>222</ssID>
+<userLT>1</userLT>
+<coaccountname>Co-account 1</coaccountname>
+<classname>Klas: 1A</classname>
+<schoolname>Example School</schoolname>
+</user>
+<user>
+<userID>111</userID>
+<text>Robin Doe</text>
+<value>Robin Doe</value>
+<selectable>on</selectable>
+<ssID>222</ssID>
+<userLT>2</userLT>
+<coaccountname>Co-account 2</coaccountname>
+<classname>Klas: 1A</classname>
+<schoolname>Example School</schoolname>
+</user>
+</users>
+</results>"""
+
 
 class TestRecipientType:
     """Test RecipientType enum."""
@@ -28,6 +62,13 @@ class TestRecipientType:
         assert RecipientType.TO.parent_node_id == "insertSearchFieldContainer_0_0"
         assert RecipientType.CC.parent_node_id == "insertSearchFieldContainer_2_0"
         assert RecipientType.BCC.parent_node_id == "insertSearchFieldContainer_3_0"
+
+    def test_coaccount_recipient_type_to_parent_node_id(self):
+        # The compose form has a second recipient block for co-accounts (parents):
+        # its To/Cc/Bcc live in containers 1/4/5 (main accounts are 0/2/3).
+        assert RecipientType.COACCOUNT_TO.parent_node_id == "insertSearchFieldContainer_1_0"
+        assert RecipientType.COACCOUNT_CC.parent_node_id == "insertSearchFieldContainer_4_0"
+        assert RecipientType.COACCOUNT_BCC.parent_node_id == "insertSearchFieldContainer_5_0"
 
 
 class TestMessageComposerFormCreate:
@@ -184,6 +225,50 @@ class TestMessageComposerFormSearchUsers:
         with pytest.raises(ValueError, match="uniqueUsc is missing"):
             form.search_users("John")
 
+    def test_search_users_defaults_to_main_to_field(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        form.search_users("John")
+
+        data = spy.call_args.kwargs["data"]
+        assert data["type"] == "0"
+        assert data["parentNodeId"] == "insertSearchFieldContainer_0_0"
+
+    def test_search_users_can_target_the_coaccount_field(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        form.search_users("Luka", RecipientType.COACCOUNT_TO)
+
+        data = spy.call_args.kwargs["data"]
+        assert data["type"] == "1"
+        assert data["parentNodeId"] == "insertSearchFieldContainer_1_0"
+
+    def test_search_users_parses_coaccount_user_lt(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm.create(session=session)
+        # A co-account search returns the parents as extra <user> entries that share the
+        # student's userID/ssID but carry userLT=1,2,... and a coaccountname.
+        requests_mock.post(
+            "https://site/?module=Messages&file=searchUsers",
+            text=_COACCOUNT_SEARCH_XML,
+        )
+
+        users, _ = form.search_users("Robin", RecipientType.COACCOUNT_TO)
+
+        assert [(u.user_id, u.ss_id, u.user_lt, u.coaccountname) for u in users] == [
+            (111, 222, 1, "Co-account 1"),
+            (111, 222, 2, "Co-account 2"),
+        ]
+
+    def test_search_users_user_lt_defaults_to_zero_for_main_accounts(self, session: Smartschool):
+        form = MessageComposerForm.create(session=session)
+
+        users, _ = form.search_users("John")
+
+        assert users
+        assert all(u.user_lt == 0 for u in users)
+
 
 class TestMessageComposerFormAddRecipient:
     """Test MessageComposerForm.add_recipient() method."""
@@ -234,6 +319,50 @@ class TestMessageComposerFormAddRecipient:
 
         with pytest.raises(ValueError, match="uniqueUsc is missing"):
             form.add_recipient(mock_user)
+
+    def test_add_coaccount_recipient_targets_coaccount_container(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        # A parent: shares the student's userID/ssID, distinguished by user_lt.
+        parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=2, coaccountname="Co-account 2")
+        form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+
+        data = spy.call_args.kwargs["data"]
+        assert data["id"] == "111"
+        assert data["ssid"] == "222"
+        assert data["typeId"] == "users"
+        assert data["type"] == "1"
+        assert data["parentNodeId"] == "insertSearchFieldContainer_1_0"
+        assert data["userlt"] == "2"
+
+    def test_add_recipient_defaults_user_lt_to_the_recipient(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
+        form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+
+        assert spy.call_args.kwargs["data"]["userlt"] == "1"
+
+    def test_add_recipient_explicit_user_lt_overrides_recipient(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
+        form.add_recipient(parent, RecipientType.COACCOUNT_TO, user_lt=2)
+
+        assert spy.call_args.kwargs["data"]["userlt"] == "2"
+
+    def test_add_group_recipient_uses_user_lt_zero(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        form.add_recipient(MessageSearchGroup(group_id=2, value="Class A", ss_id=222))
+
+        data = spy.call_args.kwargs["data"]
+        assert data["typeId"] == "groups"
+        assert data["userlt"] == "0"
 
 
 class TestMessageComposerFormAddAttachment:

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -11,6 +11,7 @@ from smartschool import (
     MessageSearchUser,
     RecipientType,
     SmartSchoolAttachmentUploadError,
+    SmartSchoolCoAccountsUnavailableError,
 )
 
 if TYPE_CHECKING:
@@ -412,6 +413,25 @@ class TestMessageComposerFormAddRecipient:
         assert data["typeId"] == "groups"
         assert data["userlt"] == "0"
 
+    def test_add_recipient_raises_on_coaccount_without_capability(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        form.can_send_to_coaccounts = False
+        spy = mocker.spy(session, "post")
+        parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
+
+        with pytest.raises(SmartSchoolCoAccountsUnavailableError):
+            form.add_recipient(parent)
+
+        # It fails before any request is sent (no half-done state).
+        assert not [c for c in spy.call_args_list if "addUserToSelected" in c.args[0]]
+
+    def test_add_main_recipient_still_works_without_coaccount_capability(self, session: Smartschool):
+        # A non-co-account (user_lt 0) add must NOT be blocked by the co-account guard.
+        form = MessageComposerForm.create(session=session)
+        form.can_send_to_coaccounts = False
+
+        form.add_recipient(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
+
 
 class TestMessageComposerFormGetCoaccounts:
     """Test MessageComposerForm.get_coaccounts()."""
@@ -442,6 +462,13 @@ class TestMessageComposerFormGetCoaccounts:
         requests_mock.post("https://site/?module=Messages&file=searchUsers", text="<results><users /></results>")
 
         assert form.get_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)) == []
+
+    def test_raises_when_account_cannot_send_to_coaccounts(self, session: Smartschool):
+        form = MessageComposerForm.create(session=session)
+        form.can_send_to_coaccounts = False  # simulate an account without the capability
+
+        with pytest.raises(SmartSchoolCoAccountsUnavailableError, match="cannot message co-accounts"):
+            form.get_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
 
 
 class TestMessageComposerFormAddAllCoaccounts:
@@ -477,6 +504,13 @@ class TestMessageComposerFormAddAllCoaccounts:
         form = MessageComposerForm.create(session=session)
 
         assert form.add_all_coaccounts() == []
+
+    def test_add_all_coaccounts_raises_when_account_lacks_capability(self, session: Smartschool):
+        form = MessageComposerForm.create(session=session)
+        form.can_send_to_coaccounts = False
+
+        with pytest.raises(SmartSchoolCoAccountsUnavailableError):
+            form.add_all_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
 
 
 class TestMessageComposerFormAddAttachment:

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -445,6 +445,22 @@ class TestMessageComposerFormAddAllCoaccounts:
         assert [c.kwargs["data"]["userlt"] for c in add_calls] == ["1", "2"]
         assert all(c.kwargs["data"]["type"] == "1" for c in add_calls)  # co-account To container
 
+    def test_adds_coaccounts_for_multiple_users(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm.create(session=session)
+        requests_mock.post("https://site/?module=Messages&file=searchUsers", text=_COACCOUNT_SEARCH_MIXED_XML)
+        student_a = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
+        student_b = MessageSearchUser(user_id=999, value="Robin Roe", ss_id=222)
+
+        added = form.add_all_coaccounts(student_a, student_b)
+
+        # Each user's own co-accounts, in order: A's two parents then B's one.
+        assert [(c.user_id, c.user_lt) for c in added] == [(111, 1), (111, 2), (999, 1)]
+
+    def test_add_all_coaccounts_with_no_users_is_a_noop(self, session: Smartschool):
+        form = MessageComposerForm.create(session=session)
+
+        assert form.add_all_coaccounts() == []
+
 
 class TestMessageComposerFormAddAttachment:
     """Test MessageComposerForm.add_attachment() method."""

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -54,6 +54,46 @@ _COACCOUNT_SEARCH_XML = """<results>
 </users>
 </results>"""
 
+# Same search but noisier: Robin Doe's own account (userLT 0) and a namesake's co-account
+# (a different userID) are also returned. add_all_coaccounts must keep only the student's
+# own co-accounts (matching userID/ssID, userLT >= 1).
+_COACCOUNT_SEARCH_MIXED_XML = """<results>
+<type>1</type>
+<ssID>222</ssID>
+<parentNodeId>insertSearchFieldContainer_1_0</parentNodeId>
+<groups />
+<users>
+<user>
+<userID>111</userID>
+<value>Robin Doe</value>
+<ssID>222</ssID>
+<userLT>0</userLT>
+<coaccountname />
+</user>
+<user>
+<userID>111</userID>
+<value>Robin Doe</value>
+<ssID>222</ssID>
+<userLT>1</userLT>
+<coaccountname>Co-account 1</coaccountname>
+</user>
+<user>
+<userID>111</userID>
+<value>Robin Doe</value>
+<ssID>222</ssID>
+<userLT>2</userLT>
+<coaccountname>Co-account 2</coaccountname>
+</user>
+<user>
+<userID>999</userID>
+<value>Robin Roe</value>
+<ssID>222</ssID>
+<userLT>1</userLT>
+<coaccountname>Co-account 1</coaccountname>
+</user>
+</users>
+</results>"""
+
 
 class TestRecipientType:
     """Test RecipientType enum."""
@@ -69,6 +109,14 @@ class TestRecipientType:
         assert RecipientType.COACCOUNT_TO.parent_node_id == "insertSearchFieldContainer_1_0"
         assert RecipientType.COACCOUNT_CC.parent_node_id == "insertSearchFieldContainer_4_0"
         assert RecipientType.COACCOUNT_BCC.parent_node_id == "insertSearchFieldContainer_5_0"
+
+    def test_is_coaccount(self):
+        assert RecipientType.COACCOUNT_TO.is_coaccount
+        assert RecipientType.COACCOUNT_CC.is_coaccount
+        assert RecipientType.COACCOUNT_BCC.is_coaccount
+        assert not RecipientType.TO.is_coaccount
+        assert not RecipientType.CC.is_coaccount
+        assert not RecipientType.BCC.is_coaccount
 
 
 class TestMessageComposerFormCreate:
@@ -363,6 +411,49 @@ class TestMessageComposerFormAddRecipient:
         data = spy.call_args.kwargs["data"]
         assert data["typeId"] == "groups"
         assert data["userlt"] == "0"
+
+
+class TestMessageComposerFormAddAllCoaccounts:
+    """Test MessageComposerForm.add_all_coaccounts() convenience."""
+
+    def test_adds_every_coaccount_of_the_student(self, session: Smartschool, requests_mock: Mocker, mocker):
+        form = MessageComposerForm.create(session=session)
+        # search_users and add_recipient both POST to .../searchUsers, so one mock serves both;
+        # add_recipient ignores the body (only needs 200).
+        requests_mock.post("https://site/?module=Messages&file=searchUsers", text=_COACCOUNT_SEARCH_XML)
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
+        spy = mocker.spy(session, "post")
+
+        added = form.add_all_coaccounts(student)
+
+        assert [(c.user_id, c.user_lt) for c in added] == [(111, 1), (111, 2)]
+        add_calls = [c for c in spy.call_args_list if "addUserToSelected" in c.args[0]]
+        assert [c.kwargs["data"]["userlt"] for c in add_calls] == ["1", "2"]
+        assert all(c.kwargs["data"]["type"] == "1" for c in add_calls)  # co-account To container
+
+    def test_keeps_only_the_students_own_coaccounts(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm.create(session=session)
+        requests_mock.post("https://site/?module=Messages&file=searchUsers", text=_COACCOUNT_SEARCH_MIXED_XML)
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
+
+        added = form.add_all_coaccounts(student)
+
+        # The student's own account (userLT 0) and the namesake (userID 999) are excluded.
+        assert [(c.user_id, c.user_lt) for c in added] == [(111, 1), (111, 2)]
+
+    def test_returns_empty_when_no_coaccounts(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm.create(session=session)
+        requests_mock.post("https://site/?module=Messages&file=searchUsers", text="<results><users /></results>")
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
+
+        assert form.add_all_coaccounts(student) == []
+
+    def test_rejects_a_non_coaccount_recipient_type(self, session: Smartschool):
+        form = MessageComposerForm.create(session=session)
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
+
+        with pytest.raises(ValueError, match="COACCOUNT"):
+            form.add_all_coaccounts(student, RecipientType.TO)
 
 
 class TestMessageComposerFormAddAttachment:

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -268,32 +268,6 @@ class TestMessageComposerFormSearchUsers:
         assert data["type"] == "0"
         assert data["parentNodeId"] == "insertSearchFieldContainer_0_0"
 
-    def test_search_users_can_target_coaccounts(self, session: Smartschool, mocker):
-        form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
-
-        form.search_users("Luka", coaccount=True)
-
-        data = spy.call_args.kwargs["data"]
-        assert data["type"] == "1"
-        assert data["parentNodeId"] == "insertSearchFieldContainer_1_0"
-
-    def test_search_users_parses_coaccount_user_lt(self, session: Smartschool, requests_mock: Mocker):
-        form = MessageComposerForm.create(session=session)
-        # A co-account search returns the parents as extra <user> entries that share the
-        # student's userID/ssID but carry userLT=1,2,... and a coaccountname.
-        requests_mock.post(
-            "https://site/?module=Messages&file=searchUsers",
-            text=_COACCOUNT_SEARCH_XML,
-        )
-
-        users, _ = form.search_users("Robin", coaccount=True)
-
-        assert [(u.user_id, u.ss_id, u.user_lt, u.coaccountname) for u in users] == [
-            (111, 222, 1, "Co-account 1"),
-            (111, 222, 2, "Co-account 2"),
-        ]
-
     def test_search_users_user_lt_defaults_to_zero_for_main_accounts(self, session: Smartschool):
         form = MessageComposerForm.create(session=session)
 

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -422,6 +422,37 @@ class TestMessageComposerFormAddRecipient:
         assert data["userlt"] == "0"
 
 
+class TestMessageComposerFormGetCoaccounts:
+    """Test MessageComposerForm.get_coaccounts()."""
+
+    def test_returns_only_the_users_own_coaccounts(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm.create(session=session)
+        requests_mock.post("https://site/?module=Messages&file=searchUsers", text=_COACCOUNT_SEARCH_MIXED_XML)
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
+
+        coaccounts = form.get_coaccounts(student)
+
+        # The student's own account (userLT 0) and a namesake (userID 999) are excluded.
+        assert [(c.user_id, c.user_lt, c.coaccountname) for c in coaccounts] == [
+            (111, 1, "Co-account 1"),
+            (111, 2, "Co-account 2"),
+        ]
+
+    def test_searches_the_coaccount_field(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        form.get_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
+
+        assert spy.call_args.kwargs["data"]["type"] == "1"  # co-account search container
+
+    def test_returns_empty_when_no_coaccounts(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm.create(session=session)
+        requests_mock.post("https://site/?module=Messages&file=searchUsers", text="<results><users /></results>")
+
+        assert form.get_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)) == []
+
+
 class TestMessageComposerFormAddAllCoaccounts:
     """Test MessageComposerForm.add_all_coaccounts() convenience."""
 
@@ -439,23 +470,6 @@ class TestMessageComposerFormAddAllCoaccounts:
         add_calls = [c for c in spy.call_args_list if "addUserToSelected" in c.args[0]]
         assert [c.kwargs["data"]["userlt"] for c in add_calls] == ["1", "2"]
         assert all(c.kwargs["data"]["type"] == "1" for c in add_calls)  # co-account To container
-
-    def test_keeps_only_the_students_own_coaccounts(self, session: Smartschool, requests_mock: Mocker):
-        form = MessageComposerForm.create(session=session)
-        requests_mock.post("https://site/?module=Messages&file=searchUsers", text=_COACCOUNT_SEARCH_MIXED_XML)
-        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
-
-        added = form.add_all_coaccounts(student)
-
-        # The student's own account (userLT 0) and the namesake (userID 999) are excluded.
-        assert [(c.user_id, c.user_lt) for c in added] == [(111, 1), (111, 2)]
-
-    def test_returns_empty_when_no_coaccounts(self, session: Smartschool, requests_mock: Mocker):
-        form = MessageComposerForm.create(session=session)
-        requests_mock.post("https://site/?module=Messages&file=searchUsers", text="<results><users /></results>")
-        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
-
-        assert form.add_all_coaccounts(student) == []
 
 
 class TestMessageComposerFormAddAttachment:

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qs
 
 import pytest
 
@@ -94,6 +95,11 @@ _COACCOUNT_SEARCH_MIXED_XML = """<results>
 </user>
 </users>
 </results>"""
+
+
+def _sent_forms(requests_mock: Mocker, url_part: str) -> list[dict[str, str]]:
+    """Form payload of every recorded request whose URL contains ``url_part``, oldest first."""
+    return [{k: v[0] for k, v in parse_qs(r.text).items()} for r in requests_mock.request_history if url_part in r.url]
 
 
 class TestRecipientType:
@@ -291,13 +297,12 @@ class TestMessageComposerFormSearchUsers:
         with pytest.raises(ValueError, match="uniqueUsc is missing"):
             form.search_users("John")
 
-    def test_search_users_defaults_to_main_accounts(self, session: Smartschool, mocker):
+    def test_search_users_defaults_to_main_accounts(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         form.search_users("John")
 
-        data = spy.call_args.kwargs["data"]
+        data = _sent_forms(requests_mock, "file=searchUsers")[-1]
         assert data["type"] == "0"
         assert data["parentNodeId"] == "insertSearchFieldContainer_0_0"
 
@@ -360,16 +365,15 @@ class TestMessageComposerFormAddRecipient:
         with pytest.raises(ValueError, match="uniqueUsc is missing"):
             form.add_recipient(mock_user)
 
-    def test_add_coaccount_is_routed_to_the_coaccount_field_automatically(self, session: Smartschool, mocker):
+    def test_add_coaccount_is_routed_to_the_coaccount_field_automatically(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         # A parent: shares the student's userID/ssID, distinguished by user_lt. The caller
         # picks the plain TO field; the co-account container (1) is chosen automatically.
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=2, coaccountname="Co-account 2")
         form.add_recipient(parent, RecipientType.TO)
 
-        data = spy.call_args.kwargs["data"]
+        data = _sent_forms(requests_mock, "addUserToSelected")[-1]
         assert data["id"] == "111"
         assert data["ssid"] == "222"
         assert data["typeId"] == "users"
@@ -377,68 +381,62 @@ class TestMessageComposerFormAddRecipient:
         assert data["parentNodeId"] == "insertSearchFieldContainer_1_0"
         assert data["userlt"] == "2"
 
-    def test_add_coaccount_as_cc_uses_the_coaccount_cc_container(self, session: Smartschool, mocker):
+    def test_add_coaccount_as_cc_uses_the_coaccount_cc_container(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
         form.add_recipient(parent, RecipientType.CC)
 
-        data = spy.call_args.kwargs["data"]
+        data = _sent_forms(requests_mock, "addUserToSelected")[-1]
         assert data["type"] == "4"
         assert data["parentNodeId"] == "insertSearchFieldContainer_4_0"
 
-    def test_add_main_account_stays_in_the_main_field(self, session: Smartschool, mocker):
+    def test_add_main_account_stays_in_the_main_field(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)  # user_lt defaults to 0
         form.add_recipient(student, RecipientType.TO)
 
-        data = spy.call_args.kwargs["data"]
+        data = _sent_forms(requests_mock, "addUserToSelected")[-1]
         assert data["type"] == "0"
         assert data["parentNodeId"] == "insertSearchFieldContainer_0_0"
         assert data["userlt"] == "0"
 
-    def test_add_recipient_defaults_user_lt_to_the_recipient(self, session: Smartschool, mocker):
+    def test_add_recipient_defaults_user_lt_to_the_recipient(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
         form.add_recipient(parent, RecipientType.TO)
 
-        assert spy.call_args.kwargs["data"]["userlt"] == "1"
+        assert _sent_forms(requests_mock, "addUserToSelected")[-1]["userlt"] == "1"
 
-    def test_add_recipient_explicit_user_lt_overrides_recipient(self, session: Smartschool, mocker):
+    def test_add_recipient_explicit_user_lt_overrides_recipient(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
         form.add_recipient(parent, RecipientType.TO, user_lt=2)
 
-        assert spy.call_args.kwargs["data"]["userlt"] == "2"
+        assert _sent_forms(requests_mock, "addUserToSelected")[-1]["userlt"] == "2"
 
-    def test_add_group_recipient_uses_user_lt_zero(self, session: Smartschool, mocker):
+    def test_add_group_recipient_uses_user_lt_zero(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         form.add_recipient(MessageSearchGroup(group_id=2, value="Class A", ss_id=222))
 
-        data = spy.call_args.kwargs["data"]
+        data = _sent_forms(requests_mock, "addUserToSelected")[-1]
         assert data["typeId"] == "groups"
         assert data["userlt"] == "0"
 
-    def test_add_recipient_raises_on_coaccount_without_capability(self, session: Smartschool, mocker):
+    def test_add_recipient_raises_on_coaccount_without_capability(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
         form.can_send_to_coaccounts = False
-        spy = mocker.spy(session, "post")
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
 
         with pytest.raises(SmartSchoolCoAccountsUnavailableError):
             form.add_recipient(parent)
 
         # It fails before any request is sent (no half-done state).
-        assert not [c for c in spy.call_args_list if "addUserToSelected" in c.args[0]]
+        assert _sent_forms(requests_mock, "addUserToSelected") == []
 
     def test_add_main_recipient_still_works_without_coaccount_capability(self, session: Smartschool):
         # A non-co-account (user_lt 0) add must NOT be blocked by the co-account guard.
@@ -464,13 +462,12 @@ class TestMessageComposerFormGetCoaccounts:
             (111, 2, "Co-account 2"),
         ]
 
-    def test_searches_the_coaccount_field(self, session: Smartschool, mocker):
+    def test_searches_the_coaccount_field(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
-        spy = mocker.spy(session, "post")
 
         form.get_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
 
-        assert spy.call_args.kwargs["data"]["type"] == "1"  # co-account search container
+        assert _sent_forms(requests_mock, "file=searchUsers")[-1]["type"] == "1"  # co-account search container
 
     def test_returns_empty_when_no_coaccounts(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
@@ -489,20 +486,19 @@ class TestMessageComposerFormGetCoaccounts:
 class TestMessageComposerFormAddAllCoaccounts:
     """Test MessageComposerForm.add_all_coaccounts() convenience."""
 
-    def test_adds_every_coaccount_of_the_student(self, session: Smartschool, requests_mock: Mocker, mocker):
+    def test_adds_every_coaccount_of_the_student(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)
         # search_users and add_recipient both POST to .../searchUsers, so one mock serves both;
         # add_recipient ignores the body (only needs 200).
         requests_mock.post("https://site/?module=Messages&file=searchUsers", text=_COACCOUNT_SEARCH_XML)
         student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
-        spy = mocker.spy(session, "post")
 
         added = form.add_all_coaccounts(student)
 
         assert [(c.user_id, c.user_lt) for c in added] == [(111, 1), (111, 2)]
-        add_calls = [c for c in spy.call_args_list if "addUserToSelected" in c.args[0]]
-        assert [c.kwargs["data"]["userlt"] for c in add_calls] == ["1", "2"]
-        assert all(c.kwargs["data"]["type"] == "1" for c in add_calls)  # co-account To container
+        add_forms = _sent_forms(requests_mock, "addUserToSelected")
+        assert [d["userlt"] for d in add_forms] == ["1", "2"]
+        assert all(d["type"] == "1" for d in add_forms)  # co-account To container
 
     def test_adds_coaccounts_for_multiple_users(self, session: Smartschool, requests_mock: Mocker):
         form = MessageComposerForm.create(session=session)

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -175,6 +175,23 @@ class TestMessageComposerFormRefresh:
         assert "file=composeMessage" in call_url
         assert "msgID=789" in call_url
 
+    def test_refresh_detects_coaccount_support(self, session: Smartschool):
+        # The compose fixture embeds "canSendToCoAccounts":true (a staff/school-gated account).
+        form = MessageComposerForm.create(session=session)
+
+        assert form.can_send_to_coaccounts is True
+
+    def test_refresh_reports_no_coaccount_support_when_flag_is_false(self, session: Smartschool, requests_mock: Mocker):
+        form = MessageComposerForm(session=session)
+        requests_mock.get(
+            "https://site/?module=Messages&file=composeMessage&boxType=inbox&composeType=0&msgID=undefined",
+            text='<html><script>var cfg={"canSendToCoAccounts":false};</script></html>',
+        )
+
+        form.refresh()
+
+        assert form.can_send_to_coaccounts is False
+
 
 class TestMessageComposerFormSetters:
     """Test MessageComposerForm setter methods."""

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -103,21 +103,6 @@ class TestRecipientType:
         assert RecipientType.CC.parent_node_id == "insertSearchFieldContainer_2_0"
         assert RecipientType.BCC.parent_node_id == "insertSearchFieldContainer_3_0"
 
-    def test_coaccount_recipient_type_to_parent_node_id(self):
-        # The compose form has a second recipient block for co-accounts (parents):
-        # its To/Cc/Bcc live in containers 1/4/5 (main accounts are 0/2/3).
-        assert RecipientType.COACCOUNT_TO.parent_node_id == "insertSearchFieldContainer_1_0"
-        assert RecipientType.COACCOUNT_CC.parent_node_id == "insertSearchFieldContainer_4_0"
-        assert RecipientType.COACCOUNT_BCC.parent_node_id == "insertSearchFieldContainer_5_0"
-
-    def test_is_coaccount(self):
-        assert RecipientType.COACCOUNT_TO.is_coaccount
-        assert RecipientType.COACCOUNT_CC.is_coaccount
-        assert RecipientType.COACCOUNT_BCC.is_coaccount
-        assert not RecipientType.TO.is_coaccount
-        assert not RecipientType.CC.is_coaccount
-        assert not RecipientType.BCC.is_coaccount
-
 
 class TestMessageComposerFormCreate:
     """Test MessageComposerForm.create() classmethod."""
@@ -273,7 +258,7 @@ class TestMessageComposerFormSearchUsers:
         with pytest.raises(ValueError, match="uniqueUsc is missing"):
             form.search_users("John")
 
-    def test_search_users_defaults_to_main_to_field(self, session: Smartschool, mocker):
+    def test_search_users_defaults_to_main_accounts(self, session: Smartschool, mocker):
         form = MessageComposerForm.create(session=session)
         spy = mocker.spy(session, "post")
 
@@ -283,11 +268,11 @@ class TestMessageComposerFormSearchUsers:
         assert data["type"] == "0"
         assert data["parentNodeId"] == "insertSearchFieldContainer_0_0"
 
-    def test_search_users_can_target_the_coaccount_field(self, session: Smartschool, mocker):
+    def test_search_users_can_target_coaccounts(self, session: Smartschool, mocker):
         form = MessageComposerForm.create(session=session)
         spy = mocker.spy(session, "post")
 
-        form.search_users("Luka", RecipientType.COACCOUNT_TO)
+        form.search_users("Luka", coaccount=True)
 
         data = spy.call_args.kwargs["data"]
         assert data["type"] == "1"
@@ -302,7 +287,7 @@ class TestMessageComposerFormSearchUsers:
             text=_COACCOUNT_SEARCH_XML,
         )
 
-        users, _ = form.search_users("Robin", RecipientType.COACCOUNT_TO)
+        users, _ = form.search_users("Robin", coaccount=True)
 
         assert [(u.user_id, u.ss_id, u.user_lt, u.coaccountname) for u in users] == [
             (111, 222, 1, "Co-account 1"),
@@ -368,13 +353,14 @@ class TestMessageComposerFormAddRecipient:
         with pytest.raises(ValueError, match="uniqueUsc is missing"):
             form.add_recipient(mock_user)
 
-    def test_add_coaccount_recipient_targets_coaccount_container(self, session: Smartschool, mocker):
+    def test_add_coaccount_is_routed_to_the_coaccount_field_automatically(self, session: Smartschool, mocker):
         form = MessageComposerForm.create(session=session)
         spy = mocker.spy(session, "post")
 
-        # A parent: shares the student's userID/ssID, distinguished by user_lt.
+        # A parent: shares the student's userID/ssID, distinguished by user_lt. The caller
+        # picks the plain TO field; the co-account container (1) is chosen automatically.
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=2, coaccountname="Co-account 2")
-        form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+        form.add_recipient(parent, RecipientType.TO)
 
         data = spy.call_args.kwargs["data"]
         assert data["id"] == "111"
@@ -384,12 +370,35 @@ class TestMessageComposerFormAddRecipient:
         assert data["parentNodeId"] == "insertSearchFieldContainer_1_0"
         assert data["userlt"] == "2"
 
+    def test_add_coaccount_as_cc_uses_the_coaccount_cc_container(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
+        form.add_recipient(parent, RecipientType.CC)
+
+        data = spy.call_args.kwargs["data"]
+        assert data["type"] == "4"
+        assert data["parentNodeId"] == "insertSearchFieldContainer_4_0"
+
+    def test_add_main_account_stays_in_the_main_field(self, session: Smartschool, mocker):
+        form = MessageComposerForm.create(session=session)
+        spy = mocker.spy(session, "post")
+
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)  # user_lt defaults to 0
+        form.add_recipient(student, RecipientType.TO)
+
+        data = spy.call_args.kwargs["data"]
+        assert data["type"] == "0"
+        assert data["parentNodeId"] == "insertSearchFieldContainer_0_0"
+        assert data["userlt"] == "0"
+
     def test_add_recipient_defaults_user_lt_to_the_recipient(self, session: Smartschool, mocker):
         form = MessageComposerForm.create(session=session)
         spy = mocker.spy(session, "post")
 
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
-        form.add_recipient(parent, RecipientType.COACCOUNT_TO)
+        form.add_recipient(parent, RecipientType.TO)
 
         assert spy.call_args.kwargs["data"]["userlt"] == "1"
 
@@ -398,7 +407,7 @@ class TestMessageComposerFormAddRecipient:
         spy = mocker.spy(session, "post")
 
         parent = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222, user_lt=1)
-        form.add_recipient(parent, RecipientType.COACCOUNT_TO, user_lt=2)
+        form.add_recipient(parent, RecipientType.TO, user_lt=2)
 
         assert spy.call_args.kwargs["data"]["userlt"] == "2"
 
@@ -447,13 +456,6 @@ class TestMessageComposerFormAddAllCoaccounts:
         student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
 
         assert form.add_all_coaccounts(student) == []
-
-    def test_rejects_a_non_coaccount_recipient_type(self, session: Smartschool):
-        form = MessageComposerForm.create(session=session)
-        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
-
-        with pytest.raises(ValueError, match="COACCOUNT"):
-            form.add_all_coaccounts(student, RecipientType.TO)
 
 
 class TestMessageComposerFormAddAttachment:

--- a/tests/message_composer_tests.py
+++ b/tests/message_composer_tests.py
@@ -478,9 +478,10 @@ class TestMessageComposerFormGetCoaccounts:
     def test_raises_when_account_cannot_send_to_coaccounts(self, session: Smartschool):
         form = MessageComposerForm.create(session=session)
         form.can_send_to_coaccounts = False  # simulate an account without the capability
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
 
         with pytest.raises(SmartSchoolCoAccountsUnavailableError, match="cannot message co-accounts"):
-            form.get_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
+            form.get_coaccounts(student)
 
 
 class TestMessageComposerFormAddAllCoaccounts:
@@ -519,9 +520,10 @@ class TestMessageComposerFormAddAllCoaccounts:
     def test_add_all_coaccounts_raises_when_account_lacks_capability(self, session: Smartschool):
         form = MessageComposerForm.create(session=session)
         form.can_send_to_coaccounts = False
+        student = MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222)
 
         with pytest.raises(SmartSchoolCoAccountsUnavailableError):
-            form.add_all_coaccounts(MessageSearchUser(user_id=111, value="Robin Doe", ss_id=222))
+            form.add_all_coaccounts(student)
 
 
 class TestMessageComposerFormAddAttachment:


### PR DESCRIPTION
Closes #169.

## What

Adds the ability to send messages to **co-accounts** (typically the parents of a student), requested in #169.

## How it works

The compose form has two recipient blocks: one for the accounts themselves and one for their co-accounts. Their To/Cc/Bcc fields map to search-field containers `1`/`4`/`5` (main accounts are `0`/`2`/`3`). A co-account is added with the **same** `addUserToSelected` request as a normal recipient, reusing the account's `userID`/`ssID` and distinguished only by `userlt` (`0` = the account, `1`, `2`, … = its co-accounts). Confirmed from a network capture of the browser flow.

Callers never deal with any of that: `RecipientType` stays just `TO`/`CC`/`BCC`, and a recipient with `user_lt > 0` is routed to the mirrored co-account container automatically.

## API

```python
form = MessageComposerForm.create(session=session)
form.set_subject("Test")
form.set_message_html("<p>Hello</p>")

students, _ = form.search_users("Firstname Lastname")
form.add_recipient(students[0], RecipientType.TO)

form.add_all_coaccounts(students[0])          # all parents in one call (variadic: *students)
# or hand-pick:
for parent in form.get_coaccounts(students[0]):
    form.add_recipient(parent, RecipientType.CC)

form.send()
```

- `MessageSearchUser.user_lt` — `0` = main account, `1+` = co-account (parsed from `<userLT>`).
- `get_coaccounts(user)` — the co-accounts belonging to that user (namesakes and the account itself filtered out).
- `add_all_coaccounts(*users, recipient_type=TO)` — adds every co-account of each user; returns them.
- `form.can_send_to_coaccounts` — messaging co-accounts is staff/school-gated; the flag is read from the `canSendToCoAccounts` boolean in the compose page's embedded SMSC vars config (the DOM block is always rendered, so it is *not* a capability signal).
- Every path that could add a co-account **fails loudly** with `SmartSchoolCoAccountsUnavailableError` when the account lacks the capability — a silent skip would mean parents silently missing a message.

## Internals / cleanup along the way

- `parse_smsc_vars()` (new, in `_common`) extracts the embedded SMSC vars config and handles both serializations Smartschool uses (raw `{ vars : {...} }` literal and `JSON.parse('…')` string); the login parser now uses it too. A warning is logged when the compose page carries no readable config, so a capability false-negative after an upstream format change is diagnosable.
- `SmartSchoolException.__str__` now returns `message`, fixing the unreadable args-tuple repr of multi-field exceptions.
- Container-id knowledge consolidated (single `_node_id()` builder + `RecipientType.coaccount_container`).
- SonarCloud findings resolved (super-linear regex, two S5778 test smells) — 0 open issues on the PR.
- CI: the codecov gate now listens on both `status` and `check_run` events and reads both APIs, fixing the `codecov-reported` check being stuck on pending forever (Codecov reports via commit statuses here, but the old gate only watched check-runs).

## Tests

TDD (red → green); new tests assert the actual HTTP payloads via `requests_mock.request_history`. Test assets fully anonymized. 316 passed, 100% branch coverage.

Follow-up: #172 (stacked) converts the remaining pre-existing spy-based tests to the same request-history style.
